### PR TITLE
Version 2.5.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
     '@typescript-eslint/lines-between-class-members': ['error', {"exceptAfterSingleLine": true}],
     '@typescript-eslint/no-base-to-string': 'error',
     '@typescript-eslint/no-explicit-any': 'error',
-    '@typescript-eslint/no-extra-parens': 'error',
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': ['error', {"allowComparingNullableBooleansToTrue": false, "allowComparingNullableBooleansToFalse": false}],
     '@typescript-eslint/no-var-requires': 'error',
     '@typescript-eslint/prefer-optional-chain': 'error',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ All notable changes to this project will be documented in this file.
 
 - `forceMax` has been added. This will force the use of `maxWidth`, `maxHeight`, `maxFPS`, and `maxBitrate` when set.
 - If `maxWidth`, `maxHeight`, or `maxFPS` are set to `0`, the width, height, or framerate of the source will now be used for the output.
+- If `maxBitrate` is set to `0`, the bitrate of the encoder will not be limited. I strongly recommend against this, but it is a better option than setting it to `999999` or similar values, as I've seen in some configs.
 - Reorganized config UI options.
+
+### Bug Fixes
+
+- Fix handling of IPv6 connections.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2.5.0 (2020-08-23)
+
+### Changes
+
+- `forceMax` has been added. This will force the use of `maxWidth`, `maxHeight`, `maxFPS`, and `maxBitrate` when set.
+- If `maxWidth`, `maxHeight`, or `maxFPS` are set to `0`, the width, height, or framerate of the source will now be used for the output.
+- Reorganized config UI options.
+
+### Breaking Changes
+
+- Horizontal and vertical flip have been removed. If you need these options, pass `hflip` and/or `vflip` in `videoFilter`.
+- `forceMax` has resulted in the removal of `minBitrate`, as it is now redundant. To replicate the old behavior, set `maxBitrate` to the bitrate you want to use and set `forceMax` to true.
+- `preserveRatio` is now a boolean to reduce confusion and support the better handling of that option.
+
 ## v2.4.7 (2020-08-17)
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Other users have been sharing configurations that work for them on our GitHub si
     {
       "name": "Camera Name",
       "videoConfig": {
-        "source": "-i rtsp://myfancy_rtsp_stream",
-        "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
+        "source": "-i rtsp://username:password@example.com:554",
+        "stillImageSource": "-i http://example.com/still_image.jpg",
         "maxStreams": 2,
         "maxWidth": 1280,
         "maxHeight": 720,
@@ -77,8 +77,8 @@ Other users have been sharing configurations that work for them on our GitHub si
       "serialNumber": "1234567890",
       "firmwareRevision": "1.0",
       "videoConfig": {
-        "source": "-i rtsp://myfancy_rtsp_stream",
-        "stillImageSource": "-i http://faster_still_image_grab_url/this_is_optional.jpg",
+        "source": "-i rtsp://username:password@example.com:554",
+        "stillImageSource": "-i http://example.com/still_image.jpg",
         "maxStreams": 2,
         "maxWidth": 1280,
         "maxHeight": 720,
@@ -91,22 +91,20 @@ Other users have been sharing configurations that work for them on our GitHub si
 
 ### Optional videoConfig Parameters
 
-- `maxStreams`: The maximum number of streams that will be allowed concurrently this camera. (Default: `2`)
-- `maxWidth`: The maximum width used for video streamed to HomeKit. If not set, will use any size HomeKit requests.
-- `maxHeight`: The maximum height used for video streamed to HomeKit. If not set, will use any size HomeKit requests.
-- `maxFPS`: The maximum frame rate used for video streamed to HomeKit. If not set, will use any frame rate HomeKit requests.
-- `minBitrate`: The minimum bitrate used for video streamed to HomeKit, in kbit/s. If set, it will override the bitrate requested by HomeKit if that is lower than this value.
+- `maxStreams`: The maximum number of streams that will be allowed at once to this camera. (Default: `2`)
+- `maxWidth`: The maximum width used for video streamed to HomeKit. If set to 0, the resolution of the source is used. If not set, will use any size HomeKit requests.
+- `maxHeight`: The maximum height used for video streamed to HomeKit. If set to 0, the resolution of the source is used. If not set, will use any size HomeKit requests.
+- `maxFPS`: The maximum frame rate used for video streamed to HomeKit. If set to 0, the framerate of the source is used. If not set, will use any frame rate HomeKit requests.
 - `maxBitrate`: The maximum bitrate used for video streamed to HomeKit, in kbit/s. If not set, will use any bitrate HomeKit requests.
-- `preserveRatio`: Can be set to preserve the aspect ratio based on either `W`idth or `H`eight. If not set, aspect ratio is not preserved.
-- `vcodec`: Set the codec used for encoding video sent to HomeKit, must be h.264-based. If you're running on a Raspberry Pi, you can change to the hardware accelerated video codec with this option. (Default: `libx264`)
+- `forceMax`: If set, the settings requested by HomeKit will be overridden with any 'maximum' values defined in this config. (Default: `false`)
+- `preserveRatio`: Preserves the aspect ratio of the source video. (Default: `false`)
+- `vcodec`: Set the codec used for encoding video sent to HomeKit, must be H.264-based.  You can change to a hardware accelerated video codec with this option, if one is available. (Default: `libx264`)
 - `audio`: Enables audio streaming from camera. (Default: `false`)
 - `packetSize`: If audio or video is choppy try a smaller value, should be set to a multiple of 188. (Default: `1316`)
-- `vflip`: Flips the video vertically. (Default: `false`)
-- `hflip`: Flips the video horizontally. (Default: `false`)
 - `mapvideo`: Selects the stream used for video. (Default: `0:0`)
 - `mapaudio`: Selects the stream used for audio. (Default: `0:1`)
-- `videoFilter`: Allows a custom video filter to be passed to FFmpeg via `-vf`.
-- `additionalCommandline` Additional extra command line options passed to FFmpeg. (Default: `-preset ultrafast -tune zerolatency`)
+- `videoFilter`: Allows additional video filter options to be passed to FFmpeg. If set to 'none', all video filters are disabled.
+- `additionalCommandline`: Allows additional command line options to be passed to FFmpeg. (Default: `-preset ultrafast -tune zerolatency`)
 - `debug`: Includes debugging output from FFmpeg in the Homebridge log. (Default: `false`)
 
 #### More Complicated Example

--- a/config.schema.json
+++ b/config.schema.json
@@ -98,7 +98,7 @@
             "description": "Set the firmware revision for display in the Home app."
           },
           "motion": {
-            "title": "Enable Motion",
+            "title": "Enable Motion Sensor",
             "type": "boolean",
             "description": "Exposes the motion sensor for this camera. This can be triggered with the dummy switches, MQTT messages, or via HTTP, depending on what features are enabled in the config."
           },
@@ -108,7 +108,7 @@
             "description": "Exposes the doorbell device for this camera. This can be triggered with the dummy switches, MQTT messages, or via HTTP, depending on what features are enabled in the config."
           },
           "switches": {
-            "title": "Enable Manual Automation Switches",
+            "title": "Enable Dummy Switches",
             "type": "boolean",
             "description": "Enables dummy switches to trigger motion and/or doorbell, if either of those are enabled. When enabled there will be an additional switch that triggers the motion or doorbell event."
           },
@@ -129,9 +129,9 @@
             "type": "object",
             "properties": {
               "source": {
-                "title": "Source",
+                "title": "Video Source",
                 "type": "string",
-                "placeholder": "-i rtsp://myfancy_rtsp_stream",
+                "placeholder": "-i rtsp://username:password@example.com:554",
                 "required": true,
                 "description": "FFmpeg options on where to find and how to decode your camera's video stream. The most basic form is '-i' followed by your camera's URL."
               },
@@ -145,51 +145,47 @@
                 "type": "integer",
                 "placeholder": 2,
                 "minimum": 1,
-                "description": "The maximum number of streams that will be allowed concurrently this camera."
+                "description": "The maximum number of streams that will be allowed at once to this camera."
               },
               "maxWidth": {
                 "title": "Maximum Width",
                 "type": "integer",
                 "placeholder": 1280,
-                "minimum": 1,
-                "description": "The maximum width used for video streamed to HomeKit. If not set, will use any size HomeKit requests."
+                "multipleOf": 2,
+                "minimum": 0,
+                "description": "The maximum width used for video streamed to HomeKit. If set to 0, the resolution of the source is used. If not set, will use any size HomeKit requests."
               },
               "maxHeight": {
                 "title": "Maximum Height",
                 "type": "integer",
                 "placeholder": 720,
-                "minimum": 1,
-                "description": "The maximum height used for video streamed to HomeKit. If not set, will use any size HomeKit requests."
+                "multipleOf": 2,
+                "minimum": 0,
+                "description": "The maximum height used for video streamed to HomeKit. If set to 0, the resolution of the source is used. If not set, will use any size HomeKit requests."
               },
               "maxFPS": {
-                "title": "Maximum FPS",
+                "title": "Maximum Framerate",
                 "type": "integer",
-                "placeholder": 10,
-                "minimum": 1,
-                "description": "The maximum frame rate used for video streamed to HomeKit. If not set, will use any frame rate HomeKit requests."
+                "placeholder": 30,
+                "minimum": 0,
+                "description": "The maximum frame rate used for video streamed to HomeKit. If set to 0, the framerate of the source is used. If not set, will use any framerate HomeKit requests."
               },
               "maxBitrate": {
                 "title": "Maximum Bitrate",
                 "type": "integer",
-                "placeholder": 300,
-                "minimum": 1,
+                "placeholder": 299,
+                "minimum": 0,
                 "description": "The maximum bitrate used for video streamed to HomeKit, in kbit/s. If not set, will use any bitrate HomeKit requests."
               },
-              "minBitrate": {
-                "title": "Minimum Bitrate",
-                "type": "integer",
-                "placeholder": 0,
-                "minimum": 0,
-                "description": "The minimum bitrate used for video streamed to HomeKit, in kbit/s. If set, it will override the bitrate requested by HomeKit if that is lower than this value."
+              "forceMax": {
+                "title": "Force Maximums",
+                "type": "boolean",
+                "description": "If set, the settings requested by HomeKit will be overridden with any 'maximum' values defined in this config."
               },
               "preserveRatio": {
                 "title": "Preserve Aspect Ratio",
-                "type": "string",
-                "oneOf": [
-                  { "title": "Width", "enum": ["W"] },
-                  { "title": "Height", "enum": ["H"] }
-                ],
-                "description": "Can be set to preserve the aspect ratio based on either Width or Height. If not set, aspect ratio is not preserved."
+                "type": "boolean",
+                "description": "Preserves the aspect ratio of the source video."
               },
               "vcodec": {
                 "title": "Video Codec",
@@ -199,39 +195,40 @@
                   "source": [
                     "libx264",
                     "h264_omx",
-                    "h264",
+                    "h264_videotoolbox",
                     "copy"
                   ]
                 },
-                "description": "Set the codec used for encoding video sent to HomeKit, must be h.264-based. If you're running on a Raspberry Pi, you can change to the hardware accelerated video codec with this option."
+                "description": "Set the codec used for encoding video sent to HomeKit, must be H.264-based. You can change to a hardware accelerated video codec with this option, if one is available."
               },
               "packetSize": {
                 "title": "Packet Size",
                 "type": "number",
                 "placeholder": 1316,
                 "multipleOf": 188,
+                "minimum": 188,
                 "description": "If audio or video is choppy try a smaller value."
               },
               "videoFilter": {
-                "title": "Custom Video Filter",
+                "title": "Additional Video Filter Options",
                 "type": "string",
-                "description": "Allows a custom video filter to be passed to FFmpeg via '-vf'."
+                "description": "Allows additional video filter options to be passed to FFmpeg. If set to 'none', all video filters are disabled."
               },
               "additionalCommandline": {
                 "title": "Additional Command Line Options",
                 "type": "string",
                 "placeholder": "-preset ultrafast -tune zerolatency",
-                "description": "Additional extra command line options passed to FFmpeg."
+                "description": "Allows additional command line options to be passed to FFmpeg."
               },
               "mapvideo": {
                 "type": "string",
-                "title": "Map Video",
+                "title": "Video Stream",
                 "placeholder": "0:0",
                 "description": "Selects the stream used for video."
               },
               "mapaudio": {
                 "type": "string",
-                "title": "Map Audio",
+                "title": "Audio Stream",
                 "placeholder": "0:1",
                 "description": "Selects the stream used for audio."
               },
@@ -239,16 +236,6 @@
                 "title": "Enable Audio",
                 "type": "boolean",
                 "description": "Enables audio streaming from camera."
-              },
-              "vflip": {
-                "title": "Flip Vertically",
-                "type": "boolean",
-                "description": "Flips the video vertically."
-              },
-              "hflip": {
-                "title": "Flip Horizontally",
-                "type": "boolean",
-                "description": "Flips the video horizontally."
               },
               "debug": {
                 "title": "Debug Logging",
@@ -277,37 +264,11 @@
             "cameras[].name",
             "cameras[].videoConfig.source",
             "cameras[].videoConfig.stillImageSource",
-            "cameras[].videoConfig.vcodec",
             "cameras[].videoConfig.audio",
-            "cameras[].unbridge",
-            {
-              "key": "cameras[].videoConfig",
-              "type": "section",
-              "title": "Advanced Settings",
-              "expandable": true,
-              "expanded": false,
-              "items": [
-                "cameras[].videoConfig.maxStreams",
-                "cameras[].videoConfig.maxWidth",
-                "cameras[].videoConfig.maxHeight",
-                "cameras[].videoConfig.maxFPS",
-                "cameras[].videoConfig.maxBitrate",
-                "cameras[].videoConfig.minBitrate",
-                "cameras[].videoConfig.preserveRatio",
-                "cameras[].videoConfig.packetSize",
-                "cameras[].videoConfig.videoFilter",
-                "cameras[].videoConfig.additionalCommandline",
-                "cameras[].videoConfig.mapvideo",
-                "cameras[].videoConfig.mapaudio",
-                "cameras[].videoConfig.vflip",
-                "cameras[].videoConfig.hflip",
-                "cameras[].videoConfig.debug"
-              ]
-            },
             {
               "key": "cameras[]",
               "type": "section",
-              "title": "Customization Settings",
+              "title": "Branding",
               "expandable": true,
               "expanded": false,
               "items": [
@@ -320,7 +281,40 @@
             {
               "key": "cameras[]",
               "type": "section",
-              "title": "Automation Settings",
+              "title": "Video Output",
+              "expandable": true,
+              "expanded": false,
+              "items": [
+                "cameras[].videoConfig.maxWidth",
+                "cameras[].videoConfig.maxHeight",
+                "cameras[].videoConfig.maxFPS",
+                "cameras[].videoConfig.maxBitrate",
+                "cameras[].videoConfig.forceMax",
+                "cameras[].videoConfig.preserveRatio",
+                "cameras[].videoConfig.videoFilter",
+                "cameras[].videoConfig.additionalCommandline"
+              ]
+            },
+            {
+              "key": "cameras[]",
+              "type": "section",
+              "title": "Advanced",
+              "expandable": true,
+              "expanded": false,
+              "items": [
+                "cameras[].videoConfig.vcodec",
+                "cameras[].videoConfig.mapvideo",
+                "cameras[].videoConfig.mapaudio",
+                "cameras[].videoConfig.maxStreams",
+                "cameras[].videoConfig.packetSize",
+                "cameras[].unbridge",
+                "cameras[].videoConfig.debug"
+              ]
+            },
+            {
+              "key": "cameras[]",
+              "type": "section",
+              "title": "Automation",
               "expandable": true,
               "expanded": false,
               "items": [
@@ -336,7 +330,7 @@
     },
     {
       "type": "section",
-      "title": "Optional Settings",
+      "title": "Global Advanced",
       "expandable": true,
       "expanded": false,
       "items": [
@@ -346,7 +340,7 @@
     },
     {
       "type": "section",
-      "title": "Automation Settings",
+      "title": "Global Automation",
       "expandable": true,
       "expanded": false,
       "items": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2138,9 +2138,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
     "uc.micro": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-camera-ffmpeg",
-  "version": "2.4.7",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,12 +107,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.9.0.tgz",
-      "integrity": "sha512-UD6b4p0/hSe1xdTvRCENSx7iQ+KR6ourlZFfYuPC7FlXEzdHuLPrEmuxZ23b2zW96KJX9Z3w05GE/wNOiEzrVg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.9.1.tgz",
+      "integrity": "sha512-XIr+Mfv7i4paEdBf0JFdIl9/tVxyj+rlilWIfZ97Be0lZ7hPvUbS5iHt9Glc8kRI53dsr0PcAEudbf8rO2wGgg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "3.9.0",
+        "@typescript-eslint/experimental-utils": "3.9.1",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -121,14 +121,14 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.9.0.tgz",
-      "integrity": "sha512-/vSHUDYizSOhrOJdjYxPNGfb4a3ibO8zd4nUKo/QBFOmxosT3cVUV7KIg8Dwi6TXlr667G7YPqFK9+VSZOorNA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.9.1.tgz",
+      "integrity": "sha512-lkiZ8iBBaYoyEKhCkkw4SAeatXyBq9Ece5bZXdLe1LWBUwTszGbmbiqmQbwWA8cSYDnjWXp9eDbXpf9Sn0hLAg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/types": "3.9.0",
-        "@typescript-eslint/typescript-estree": "3.9.0",
+        "@typescript-eslint/types": "3.9.1",
+        "@typescript-eslint/typescript-estree": "3.9.1",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
@@ -193,19 +193,19 @@
       }
     },
     "@typescript-eslint/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-rb6LDr+dk9RVVXO/NJE8dT1pGlso3voNdEIN8ugm4CWM5w5GimbThCMiMl4da1t5u3YwPWEwOnKAULCZgBtBHg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.9.1.tgz",
+      "integrity": "sha512-15JcTlNQE1BsYy5NBhctnEhEoctjXOjOK+Q+rk8ugC+WXU9rAcS2BYhoh6X4rOaXJEpIYDl+p7ix+A5U0BqPTw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.9.0.tgz",
-      "integrity": "sha512-N+158NKgN4rOmWVfvKOMoMFV5n8XxAliaKkArm/sOypzQ0bUL8MSnOEBW3VFIeffb/K5ce/cAV0yYhR7U4ALAA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.9.1.tgz",
+      "integrity": "sha512-IqM0gfGxOmIKPhiHW/iyAEXwSVqMmR2wJ9uXHNdFpqVvPaQ3dWg302vW127sBpAiqM9SfHhyS40NKLsoMpN2KA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "3.9.0",
-        "@typescript-eslint/visitor-keys": "3.9.0",
+        "@typescript-eslint/types": "3.9.1",
+        "@typescript-eslint/visitor-keys": "3.9.1",
         "debug": "^4.1.1",
         "glob": "^7.1.6",
         "is-glob": "^4.0.1",
@@ -215,9 +215,9 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.9.0.tgz",
-      "integrity": "sha512-O1qeoGqDbu0EZUC/MZ6F1WHTIzcBVhGqDj3LhTnj65WUA548RXVxUHbYhAW9bZWfb2rnX9QsbbP5nmeJ5Z4+ng==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.9.1.tgz",
+      "integrity": "sha512-zxdtUjeoSh+prCpogswMwVUJfEFmCOjdzK9rpNjNBfm6EyPt99x3RrJoBOGZO23FCt0WPKUCOL5mb/9D5LjdwQ==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,9 +101,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
-      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
+      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2023,9 +2023,9 @@
       }
     },
     "systeminformation": {
-      "version": "4.26.10",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.26.10.tgz",
-      "integrity": "sha512-bO4FIzrjESAfh4KHwkUJym3jvKtJ4oJ2PG0BBQGBmKa0pF2oanpkB7CF4ZsSX7vfp3+GKaLzioVwpV/3Tyk+lQ=="
+      "version": "4.26.11",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.26.11.tgz",
+      "integrity": "sha512-+298nMYTH/MSmxMS4ekTejFtB0IkTkD4ZltG6Wn1qM56jEnx1ePpsR+7r8XiWWPnjpt27Rw/NEWAJCwPtBNCNw=="
     },
     "table": {
       "version": "5.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,62 +134,16 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.9.0.tgz",
-      "integrity": "sha512-rDHOKb6uW2jZkHQniUQVZkixQrfsZGUCNWWbKWep4A5hGhN5dLHMUCNAWnC4tXRlHedXkTDptIpxs6e4Pz8UfA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.9.1.tgz",
+      "integrity": "sha512-y5QvPFUn4Vl4qM40lI+pNWhTcOWtpZAJ8pOEQ21fTTW4xTJkRplMjMRje7LYTXqVKKX9GJhcyweMz2+W1J5bMg==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "3.9.0",
-        "@typescript-eslint/types": "3.9.0",
-        "@typescript-eslint/typescript-estree": "3.9.0",
+        "@typescript-eslint/experimental-utils": "3.9.1",
+        "@typescript-eslint/types": "3.9.1",
+        "@typescript-eslint/typescript-estree": "3.9.1",
         "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.9.0.tgz",
-          "integrity": "sha512-/vSHUDYizSOhrOJdjYxPNGfb4a3ibO8zd4nUKo/QBFOmxosT3cVUV7KIg8Dwi6TXlr667G7YPqFK9+VSZOorNA==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.3",
-            "@typescript-eslint/types": "3.9.0",
-            "@typescript-eslint/typescript-estree": "3.9.0",
-            "eslint-scope": "^5.0.0",
-            "eslint-utils": "^2.0.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.9.0.tgz",
-          "integrity": "sha512-rb6LDr+dk9RVVXO/NJE8dT1pGlso3voNdEIN8ugm4CWM5w5GimbThCMiMl4da1t5u3YwPWEwOnKAULCZgBtBHg==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.9.0.tgz",
-          "integrity": "sha512-N+158NKgN4rOmWVfvKOMoMFV5n8XxAliaKkArm/sOypzQ0bUL8MSnOEBW3VFIeffb/K5ce/cAV0yYhR7U4ALAA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "3.9.0",
-            "@typescript-eslint/visitor-keys": "3.9.0",
-            "debug": "^4.1.1",
-            "glob": "^7.1.6",
-            "is-glob": "^4.0.1",
-            "lodash": "^4.17.15",
-            "semver": "^7.3.2",
-            "tsutils": "^3.17.1"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.9.0.tgz",
-          "integrity": "sha512-O1qeoGqDbu0EZUC/MZ6F1WHTIzcBVhGqDj3LhTnj65WUA548RXVxUHbYhAW9bZWfb2rnX9QsbbP5nmeJ5Z4+ng==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        }
       }
     },
     "@typescript-eslint/types": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
-    "@types/node": "14.0.27",
+    "@types/node": "14.6.0",
     "eslint": "^7.5.0",
     "homebridge": "^1.1.1",
     "markdownlint-cli": "^0.23.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Camera FFmpeg",
   "name": "homebridge-camera-ffmpeg",
-  "version": "2.4.7",
+  "version": "2.5.0",
   "description": "Homebridge Plugin Providing FFmpeg-based Camera Support",
   "main": "dist/index.js",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "homebridge": "^1.1.1",
     "markdownlint-cli": "^0.23.2",
     "rimraf": "^3.0.2",
-    "typescript": "^3.9.7"
+    "typescript": "^4.0.2"
   },
   "dependencies": {
     "ffmpeg-for-homebridge": "0.0.7",

--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -34,8 +34,8 @@ export type VideoConfig = {
   maxHeight: number;
   maxFPS: number;
   maxBitrate: number;
-  minBitrate: number;
-  preserveRatio: string;
+  forceMax: boolean;
+  preserveRatio: boolean;
   vcodec: string;
   packetSize: number;
   videoFilter: string;
@@ -43,7 +43,5 @@ export type VideoConfig = {
   mapvideo: string;
   mapaudio: string;
   audio: boolean;
-  vflip: boolean;
-  hflip: boolean;
   debug: boolean;
 };

--- a/src/ffmpeg.ts
+++ b/src/ffmpeg.ts
@@ -1,35 +1,16 @@
 import { ChildProcess, spawn } from 'child_process';
-import { createSocket } from 'dgram';
 import { StreamRequestCallback } from 'homebridge';
 import { Logger } from './logger';
 import { StreamingDelegate } from './streamingDelegate';
 
 export class FfmpegProcess {
   private readonly process: ChildProcess;
-  private timeout?: NodeJS.Timeout;
 
-  constructor(cameraName: string, sessionId: string, videoProcessor: string, ffmpegArgs: string, log: Logger,
-    returnPort: number, debug: boolean, delegate: StreamingDelegate, callback: StreamRequestCallback) {
+  constructor(cameraName: string, sessionId: string, videoProcessor: string, ffmpegArgs: string,
+    log: Logger, debug: boolean, delegate: StreamingDelegate, callback: StreamRequestCallback) {
     let started = false;
 
     log.debug('Stream command: ' + videoProcessor + ' ' + ffmpegArgs, cameraName, debug);
-
-    const socket = createSocket('udp4');
-    socket.on('error', (err: Error) => {
-      log.error('Socket error: ' + err.name, cameraName);
-      delegate.stopStream(sessionId);
-    });
-    socket.on('message', () => {
-      if (this.timeout) {
-        clearTimeout(this.timeout);
-      }
-      this.timeout = setTimeout(() => {
-        log.info('Device appears to be inactive for over 5 seconds. Stopping stream.', cameraName);
-        delegate.controller.forceStopStreamingSession(sessionId);
-        delegate.stopStream(sessionId);
-      }, 5000);
-    });
-    socket.bind(returnPort);
 
     this.process = spawn(videoProcessor, ffmpegArgs.split(/\s+/), { env: process.env });
 
@@ -56,11 +37,11 @@ export class FfmpegProcess {
     }
     this.process.on('error', (error: Error) => {
       log.error('Failed to start stream: ' + error.message, cameraName);
-      callback(new Error('ffmpeg process creation failed!'));
+      callback(new Error('FFmpeg process creation failed!'));
       delegate.stopStream(sessionId);
     });
     this.process.on('exit', (code: number, signal: NodeJS.Signals) => {
-      const message = 'ffmpeg exited with code: ' + code + ' and signal: ' + signal;
+      const message = 'FFmpeg exited with code: ' + code + ' and signal: ' + signal;
 
       if (code == null || code === 255) {
         if (this.process.killed) {
@@ -81,9 +62,6 @@ export class FfmpegProcess {
   }
 
   public stop(): void {
-    if (this.timeout) {
-      clearTimeout(this.timeout);
-    }
     this.process.kill('SIGKILL');
   }
 }

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -139,10 +139,10 @@ export class StreamingDelegate implements CameraStreamingDelegate {
     // In the case of null, skip entirely
     if (videoFilter !== null && videoFilter !== 'none') {
       if (this.videoConfig.vflip) {
-        vf.push('hflip');
+        vf.push('vflip');
       }
       if (this.videoConfig.hflip) {
-        vf.push('vflip');
+        vf.push('hflip');
       }
       vf.push(videoFilter); // vflip and hflip filters must precede the scale filter to work
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,9 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "removeComments": true
+    "removeComments": true,
+    "declaration": true,
+    "declarationMap": true
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
### Changes

- `forceMax` has been added. This will force the use of `maxWidth`, `maxHeight`, `maxFPS`, and `maxBitrate` when set.
- If `maxWidth`, `maxHeight`, or `maxFPS` are set to `0`, the width, height, or framerate of the source will now be used for the output.
- If `maxBitrate` is set to `0`, the bitrate of the encoder will not be limited. I strongly recommend against this, but it is a better option than setting it to `999999` or similar values, as I've seen in some configs.
- Reorganized config UI options.

### Bug Fixes

- Fix handling of IPv6 connections.

### Breaking Changes

- Horizontal and vertical flip have been removed. If you need these options, pass `hflip` and/or `vflip` in `videoFilter`.
- `forceMax` has resulted in the removal of `minBitrate`, as it is now redundant. To replicate the old behavior, set `maxBitrate` to the bitrate you want to use and set `forceMax` to true.
- `preserveRatio` is now a boolean to reduce confusion and support the better handling of that option.