### PR TITLE
Version 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
-## v2.6.0 (2020-??-??)
+## v3.0.0 (2020-08-24)
 
 ### Changes
 
-- This plugin now includes experimental two-way audio support. Be aware that this feature is likely to be tweaked in the future, and a configuration that works now may need to be altered in the future.
+- This plugin now includes __experimental__ two-way audio support. Be aware that this feature is likely to be tweaked in the future, and a configuration that works now may need to be altered in the future.
 - Better detection of audio and video streams. There should be very few scenarios where `mapvideo` or `mapaudio` are needed anymore, as FFmpeg's stream auto-selection is now set up.
+- Default `videoFilter` can be disabled by including `none` in your comma-delimited list of filters.
+- Further reorganization of the config UI.
 
 ### Bug Fixes
 
-- Correct handling of inactive camera timeouts. You should no longer see timeout messages after cleanly closing a camera stream.
+- Corrected handling of inactive camera timeouts. You should no longer see timeout messages after cleanly closing a camera stream.
+- Fixed `forceMax` not applying to resolution in some scenarios.
 
 ### Breaking Changes
 
 - `additionalCommandline` has been replaced by `encoderOptions` to better reflect it's intended use.
+- `preserveRatio` has been removed and is now active as long as the default `videoFilter` list is active.
 
 ## v2.5.0 (2020-08-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## v2.6.0 (2020-??-??)
+
+### Changes
+
+- This plugin now includes experimental two-way audio support. Be aware that this feature is likely to be tweaked in the future, and a configuration that works now may need to be altered in the future.
+- Better detection of audio and video streams. There should be very few scenarios where `mapvideo` or `mapaudio` are needed anymore, as FFmpeg's stream auto-selection is now set up.
+
+### Bug Fixes
+
+- Correct handling of inactive camera timeouts. You should no longer see timeout messages after cleanly closing a camera stream.
+
+### Breaking Changes
+
+- `additionalCommandline` has been replaced by `encoderOptions` to better reflect it's intended use.
+
 ## v2.5.0 (2020-08-23)
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -91,21 +91,20 @@ Other users have been sharing configurations that work for them on our GitHub si
 
 ### Optional videoConfig Parameters
 
-- `returnAudioTarget`: _(EXPERIMENTAL)_ The FFmpeg output command for directing audio back to a two-way capable camera.
+- `returnAudioTarget`: _(EXPERIMENTAL - WIP)_ The FFmpeg output command for directing audio back to a two-way capable camera. This feature is still in development and a configuration that works today may not work in the future.
 - `maxStreams`: The maximum number of streams that will be allowed at once to this camera. (Default: `2`)
 - `maxWidth`: The maximum width used for video streamed to HomeKit. If set to 0, the resolution of the source is used. If not set, will use any size HomeKit requests.
 - `maxHeight`: The maximum height used for video streamed to HomeKit. If set to 0, the resolution of the source is used. If not set, will use any size HomeKit requests.
 - `maxFPS`: The maximum frame rate used for video streamed to HomeKit. If set to 0, the framerate of the source is used. If not set, will use any frame rate HomeKit requests.
 - `maxBitrate`: The maximum bitrate used for video streamed to HomeKit, in kbit/s. If not set, will use any bitrate HomeKit requests.
 - `forceMax`: If set, the settings requested by HomeKit will be overridden with any 'maximum' values defined in this config. (Default: `false`)
-- `preserveRatio`: Preserves the aspect ratio of the source video. (Default: `false`)
 - `vcodec`: Set the codec used for encoding video sent to HomeKit, must be H.264-based.  You can change to a hardware accelerated video codec with this option, if one is available. (Default: `libx264`)
 - `audio`: Enables audio streaming from camera. (Default: `false`)
 - `packetSize`: If audio or video is choppy try a smaller value, should be set to a multiple of 188. (Default: `1316`)
 - `mapvideo`: Selects the stream used for video. (Default: FFmpeg [automatically selects](https://ffmpeg.org/ffmpeg.html#Automatic-stream-selection) a video stream)
 - `mapaudio`: Selects the stream used for audio. (Default: FFmpeg [automatically selects](https://ffmpeg.org/ffmpeg.html#Automatic-stream-selection) an audio stream)
-- `videoFilter`: Allows additional video filter options to be passed to FFmpeg. If set to 'none', all video filters are disabled.
-- `encoderParameters`: Options to be passed to the video encoder. (Default: `-preset ultrafast -tune zerolatency` if using libx264)
+- `videoFilter`: Comma-delimited list of additional video filters for FFmpeg to run on the video. If 'none' is included, the default video filters are disabled.
+- `encoderOptions`: Options to be passed to the video encoder. (Default: `-preset ultrafast -tune zerolatency` if using libx264)
 - `debug`: Includes debugging output from the main FFmpeg process in the Homebridge log. (Default: `false`)
 - `debugReturn`: Includes debugging output from the FFmpeg used for return audio in the Homebridge log. (Default: `false`)
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Other users have been sharing configurations that work for them on our GitHub si
 
 ### Optional videoConfig Parameters
 
+- `returnAudioTarget`: _(EXPERIMENTAL)_ The FFmpeg output command for directing audio back to a two-way capable camera.
 - `maxStreams`: The maximum number of streams that will be allowed at once to this camera. (Default: `2`)
 - `maxWidth`: The maximum width used for video streamed to HomeKit. If set to 0, the resolution of the source is used. If not set, will use any size HomeKit requests.
 - `maxHeight`: The maximum height used for video streamed to HomeKit. If set to 0, the resolution of the source is used. If not set, will use any size HomeKit requests.
@@ -101,11 +102,12 @@ Other users have been sharing configurations that work for them on our GitHub si
 - `vcodec`: Set the codec used for encoding video sent to HomeKit, must be H.264-based.  You can change to a hardware accelerated video codec with this option, if one is available. (Default: `libx264`)
 - `audio`: Enables audio streaming from camera. (Default: `false`)
 - `packetSize`: If audio or video is choppy try a smaller value, should be set to a multiple of 188. (Default: `1316`)
-- `mapvideo`: Selects the stream used for video. (Default: `0:0`)
-- `mapaudio`: Selects the stream used for audio. (Default: `0:1`)
+- `mapvideo`: Selects the stream used for video. (Default: FFmpeg [automatically selects](https://ffmpeg.org/ffmpeg.html#Automatic-stream-selection) a video stream)
+- `mapaudio`: Selects the stream used for audio. (Default: FFmpeg [automatically selects](https://ffmpeg.org/ffmpeg.html#Automatic-stream-selection) an audio stream)
 - `videoFilter`: Allows additional video filter options to be passed to FFmpeg. If set to 'none', all video filters are disabled.
-- `additionalCommandline`: Allows additional command line options to be passed to FFmpeg. (Default: `-preset ultrafast -tune zerolatency`)
-- `debug`: Includes debugging output from FFmpeg in the Homebridge log. (Default: `false`)
+- `encoderParameters`: Options to be passed to the video encoder. (Default: `-preset ultrafast -tune zerolatency` if using libx264)
+- `debug`: Includes debugging output from the main FFmpeg process in the Homebridge log. (Default: `false`)
+- `debugReturn`: Includes debugging output from the FFmpeg used for return audio in the Homebridge log. (Default: `false`)
 
 #### More Complicated Example
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -141,9 +141,9 @@
                 "description": "If your camera also provides a URL for a still image, that can be defined here with the same syntax as 'source'. If not set, the plugin will grab one frame from 'source'."
               },
               "returnAudioTarget": {
-                "title": "Return Audio Target (EXPERIMENTAL)",
+                "title": "Two-way Audio Target (EXPERIMENTAL - WIP)",
                 "type": "string",
-                "description": "The FFmpeg output command for directing audio back to a two-way capable camera."
+                "description": "The FFmpeg output command for directing audio back to a two-way capable camera. This feature is still in development and a configuration that works today may not work in the future."
               },
               "maxStreams": {
                 "title": "Maximum Concurrent Streams",
@@ -215,11 +215,11 @@
                 "description": "If audio or video is choppy try a smaller value."
               },
               "videoFilter": {
-                "title": "Additional Video Filter Options",
+                "title": "Additional Video Filters",
                 "type": "string",
-                "description": "Allows additional video filter options to be passed to FFmpeg. If set to 'none', all video filters are disabled."
+                "description": "Comma-delimited list of additional video filters for FFmpeg to run on the video. If 'none' is included, the default video filters are disabled."
               },
-              "encoderParameters": {
+              "encoderOptions": {
                 "title": "Encoder Options",
                 "type": "string",
                 "placeholder": "-preset ultrafast -tune zerolatency",
@@ -241,14 +241,14 @@
                 "description": "Enables audio streaming from camera."
               },
               "debug": {
-                "title": "Debug Logging",
+                "title": "FFmpeg Debug Logging",
                 "type": "boolean",
                 "description": "Includes debugging output from the main FFmpeg process in the Homebridge log."
               },
               "debugReturn": {
-                "title": "Return Audio Debug Logging",
+                "title": "Two-way FFmpeg Debug Logging",
                 "type": "boolean",
-                "description": "Includes debugging output from the FFmpeg used for return audio in the Homebridge log."
+                "description": "Includes debugging output from the FFmpeg process used for two-way audio in the Homebridge log."
               }
             }
           }
@@ -293,14 +293,13 @@
               "expandable": true,
               "expanded": false,
               "items": [
+                "cameras[].unbridge",
+                "cameras[].videoConfig.maxStreams",
                 "cameras[].videoConfig.maxWidth",
                 "cameras[].videoConfig.maxHeight",
                 "cameras[].videoConfig.maxFPS",
                 "cameras[].videoConfig.maxBitrate",
-                "cameras[].videoConfig.forceMax",
-                "cameras[].videoConfig.preserveRatio",
-                "cameras[].videoConfig.videoFilter",
-                "cameras[].videoConfig.additionalCommandline"
+                "cameras[].videoConfig.forceMax"
               ]
             },
             {
@@ -310,15 +309,24 @@
               "expandable": true,
               "expanded": false,
               "items": [
-                "cameras[].videoConfig.returnAudioTarget",
+                {
+                  "key": "cameras[]",
+                  "type": "section",
+                  "title": "EXPERIMENTAL - WIP",
+                  "expandable": true,
+                  "expanded": false,
+                  "items": [
+                    "cameras[].videoConfig.returnAudioTarget",
+                    "cameras[].videoConfig.debugReturn"
+                  ]
+                },
                 "cameras[].videoConfig.vcodec",
+                "cameras[].videoConfig.packetSize",
                 "cameras[].videoConfig.mapvideo",
                 "cameras[].videoConfig.mapaudio",
-                "cameras[].videoConfig.maxStreams",
-                "cameras[].videoConfig.packetSize",
-                "cameras[].unbridge",
-                "cameras[].videoConfig.debug",
-                "cameras[].videoConfig.debugReturn"
+                "cameras[].videoConfig.videoFilter",
+                "cameras[].videoConfig.encoderOptions",
+                "cameras[].videoConfig.debug"
               ]
             },
             {

--- a/config.schema.json
+++ b/config.schema.json
@@ -140,6 +140,11 @@
                 "type": "string",
                 "description": "If your camera also provides a URL for a still image, that can be defined here with the same syntax as 'source'. If not set, the plugin will grab one frame from 'source'."
               },
+              "returnAudioTarget": {
+                "title": "Return Audio Target (EXPERIMENTAL)",
+                "type": "string",
+                "description": "The FFmpeg output command for directing audio back to a two-way capable camera."
+              },
               "maxStreams": {
                 "title": "Maximum Concurrent Streams",
                 "type": "integer",
@@ -214,22 +219,20 @@
                 "type": "string",
                 "description": "Allows additional video filter options to be passed to FFmpeg. If set to 'none', all video filters are disabled."
               },
-              "additionalCommandline": {
-                "title": "Additional Command Line Options",
+              "encoderParameters": {
+                "title": "Encoder Options",
                 "type": "string",
                 "placeholder": "-preset ultrafast -tune zerolatency",
-                "description": "Allows additional command line options to be passed to FFmpeg."
+                "description": "Options to be passed to the video encoder."
               },
               "mapvideo": {
                 "type": "string",
                 "title": "Video Stream",
-                "placeholder": "0:0",
                 "description": "Selects the stream used for video."
               },
               "mapaudio": {
                 "type": "string",
                 "title": "Audio Stream",
-                "placeholder": "0:1",
                 "description": "Selects the stream used for audio."
               },
               "audio": {
@@ -240,7 +243,12 @@
               "debug": {
                 "title": "Debug Logging",
                 "type": "boolean",
-                "description": "Includes debugging output from FFmpeg in the Homebridge log."
+                "description": "Includes debugging output from the main FFmpeg process in the Homebridge log."
+              },
+              "debugReturn": {
+                "title": "Return Audio Debug Logging",
+                "type": "boolean",
+                "description": "Includes debugging output from the FFmpeg used for return audio in the Homebridge log."
               }
             }
           }
@@ -302,13 +310,15 @@
               "expandable": true,
               "expanded": false,
               "items": [
+                "cameras[].videoConfig.returnAudioTarget",
                 "cameras[].videoConfig.vcodec",
                 "cameras[].videoConfig.mapvideo",
                 "cameras[].videoConfig.mapaudio",
                 "cameras[].videoConfig.maxStreams",
                 "cameras[].videoConfig.packetSize",
                 "cameras[].unbridge",
-                "cameras[].videoConfig.debug"
+                "cameras[].videoConfig.debug",
+                "cameras[].videoConfig.debugReturn"
               ]
             },
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-camera-ffmpeg",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,12 +107,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.9.1.tgz",
-      "integrity": "sha512-XIr+Mfv7i4paEdBf0JFdIl9/tVxyj+rlilWIfZ97Be0lZ7hPvUbS5iHt9Glc8kRI53dsr0PcAEudbf8rO2wGgg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.10.0.tgz",
+      "integrity": "sha512-Bbeg9JAnSzZ85Y0gpInZscSpifA6SbEgRryaKdP5ZlUjhTKsvZS4GUIE6xAZCjhNTrf4zXXsySo83ZdHL7it0w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "3.9.1",
+        "@typescript-eslint/experimental-utils": "3.10.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -121,45 +121,45 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.9.1.tgz",
-      "integrity": "sha512-lkiZ8iBBaYoyEKhCkkw4SAeatXyBq9Ece5bZXdLe1LWBUwTszGbmbiqmQbwWA8cSYDnjWXp9eDbXpf9Sn0hLAg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.0.tgz",
+      "integrity": "sha512-e5ZLSTuXgqC/Gq3QzK2orjlhTZVXzwxDujQmTBOM1NIVBZgW3wiIZjaXuVutk9R4UltFlwC9UD2+bdxsA7yyNg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/types": "3.9.1",
-        "@typescript-eslint/typescript-estree": "3.9.1",
+        "@typescript-eslint/types": "3.10.0",
+        "@typescript-eslint/typescript-estree": "3.10.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.9.1.tgz",
-      "integrity": "sha512-y5QvPFUn4Vl4qM40lI+pNWhTcOWtpZAJ8pOEQ21fTTW4xTJkRplMjMRje7LYTXqVKKX9GJhcyweMz2+W1J5bMg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.10.0.tgz",
+      "integrity": "sha512-iJyf3f2HVwscvJR7ySGMXw2DJgIAPKEz8TeU17XVKzgJRV4/VgCeDFcqLzueRe7iFI2gv+Tln4AV88ZOnsCNXg==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "3.9.1",
-        "@typescript-eslint/types": "3.9.1",
-        "@typescript-eslint/typescript-estree": "3.9.1",
+        "@typescript-eslint/experimental-utils": "3.10.0",
+        "@typescript-eslint/types": "3.10.0",
+        "@typescript-eslint/typescript-estree": "3.10.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.9.1.tgz",
-      "integrity": "sha512-15JcTlNQE1BsYy5NBhctnEhEoctjXOjOK+Q+rk8ugC+WXU9rAcS2BYhoh6X4rOaXJEpIYDl+p7ix+A5U0BqPTw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.10.0.tgz",
+      "integrity": "sha512-ktUWSa75heQNwH85GRM7qP/UUrXqx9d6yIdw0iLO9/uE1LILW+i+3+B64dUodUS2WFWLzKTlwfi9giqrODibWg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.9.1.tgz",
-      "integrity": "sha512-IqM0gfGxOmIKPhiHW/iyAEXwSVqMmR2wJ9uXHNdFpqVvPaQ3dWg302vW127sBpAiqM9SfHhyS40NKLsoMpN2KA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.0.tgz",
+      "integrity": "sha512-yjuY6rmVHRhcUKgXaSPNVloRueGWpFNhxR5EQLzxXfiFSl1U/+FBqHhbaGwtPPEgCSt61QNhZgiFjWT27bgAyw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "3.9.1",
-        "@typescript-eslint/visitor-keys": "3.9.1",
+        "@typescript-eslint/types": "3.10.0",
+        "@typescript-eslint/visitor-keys": "3.10.0",
         "debug": "^4.1.1",
         "glob": "^7.1.6",
         "is-glob": "^4.0.1",
@@ -169,9 +169,9 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.9.1.tgz",
-      "integrity": "sha512-zxdtUjeoSh+prCpogswMwVUJfEFmCOjdzK9rpNjNBfm6EyPt99x3RrJoBOGZO23FCt0WPKUCOL5mb/9D5LjdwQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.0.tgz",
+      "integrity": "sha512-g4qftk8lWb/rHZe9uEp8oZSvsJhUvR2cfp7F7qE6DyUD2SsovEs8JDQTRP1xHzsD+pERsEpYNqkDgQXW6+ob5A==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
@@ -270,12 +270,25 @@
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "bonjour-hap": {
@@ -298,6 +311,15 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-from": {
@@ -798,9 +820,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
         }
       }
     },
@@ -1059,6 +1081,11 @@
         "semver": "^7.3.2",
         "source-map-support": "^0.5.19"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -1472,9 +1499,9 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mqtt": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.0.tgz",
-      "integrity": "sha512-CGMLigAKCp0hknWPM15yuZRbVrfQjZCG9Wn3GXDEfY2chDmUi5GT3UQ3OhTtMi7fELYb2s4Q/QiWv+dECQ7ZQg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.1.tgz",
+      "integrity": "sha512-Iv893r+jWlo5GkNcPOfCGwW8M49IixwHiKLFFYTociEymSibUVCORVEjPXWPGzSxhn7BdlUeHicbRmWiv0Crkg==",
       "requires": {
         "base64-js": "^1.3.0",
         "commist": "^1.0.0",
@@ -1495,15 +1522,15 @@
       }
     },
     "mqtt-packet": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.3.2.tgz",
-      "integrity": "sha512-i56+2kN6F57KInGtjjfUXSl4xG8u/zOvfaXFLKFAbBXzWkXOmwcmjaSCBPayf2IQCkQU0+h+S2DizCo3CF6gQA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.4.0.tgz",
+      "integrity": "sha512-dNd1RPyBolklOR27hgHhy3TxkDk31ZaDu4ljAgJoHlnVsdACH8guwEZhpk3ZMn6GAdH6ENDLgtE285FHIiXzxA==",
       "requires": {
-        "bl": "^1.2.2",
+        "bl": "^4.0.2",
         "debug": "^4.1.1",
-        "inherits": "^2.0.3",
-        "process-nextick-args": "^2.0.0",
-        "safe-buffer": "^5.1.2"
+        "inherits": "^2.0.4",
+        "process-nextick-args": "^2.0.1",
+        "safe-buffer": "^5.2.1"
       }
     },
     "ms": {
@@ -1905,9 +1932,9 @@
       }
     },
     "split2": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
-      "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "requires": {
         "readable-stream": "^3.0.0"
       },
@@ -2023,9 +2050,9 @@
       }
     },
     "systeminformation": {
-      "version": "4.26.11",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.26.11.tgz",
-      "integrity": "sha512-+298nMYTH/MSmxMS4ekTejFtB0IkTkD4ZltG6Wn1qM56jEnx1ePpsR+7r8XiWWPnjpt27Rw/NEWAJCwPtBNCNw=="
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.27.0.tgz",
+      "integrity": "sha512-6hri7xMFmFT0oV8Z90w+FV6tMYuoAv+/uc7OsyGN55iwmRATPCS81R/q7js5AtkUx5e0aH5i6MdojzSlJvFnVQ=="
     },
     "table": {
       "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -60,19 +60,19 @@
     "README.md"
   ],
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.7.0",
-    "@typescript-eslint/parser": "^3.7.0",
-    "@types/node": "14.6.0",
-    "eslint": "^7.5.0",
-    "homebridge": "^1.1.1",
+    "@typescript-eslint/eslint-plugin": "^3.10.0",
+    "@typescript-eslint/parser": "^3.10.0",
+    "@types/node": "^14.6.0",
+    "eslint": "^7.7.0",
+    "homebridge": "^1.1.2",
     "markdownlint-cli": "^0.23.2",
     "rimraf": "^3.0.2",
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "ffmpeg-for-homebridge": "0.0.7",
+    "ffmpeg-for-homebridge": "^0.0.7",
     "get-port": "^5.1.1",
-    "mqtt": "^4.1.0",
-    "systeminformation": "^4.26.10"
+    "mqtt": "^4.2.1",
+    "systeminformation": "^4.27.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Camera FFmpeg",
   "name": "homebridge-camera-ffmpeg",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "Homebridge Plugin Providing FFmpeg-based Camera Support",
   "main": "dist/index.js",
   "license": "ISC",

--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -36,11 +36,10 @@ export type VideoConfig = {
   maxFPS: number;
   maxBitrate: number;
   forceMax: boolean;
-  preserveRatio: boolean;
   vcodec: string;
   packetSize: number;
   videoFilter: string;
-  encoderParameters: string;
+  encoderOptions: string;
   mapvideo: string;
   mapaudio: string;
   audio: boolean;

--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -29,6 +29,7 @@ export type CameraConfig = {
 export type VideoConfig = {
   source: string;
   stillImageSource: string;
+  returnAudioTarget: string;
   maxStreams: number;
   maxWidth: number;
   maxHeight: number;
@@ -39,9 +40,10 @@ export type VideoConfig = {
   vcodec: string;
   packetSize: number;
   videoFilter: string;
-  additionalCommandline: string;
+  encoderParameters: string;
   mapvideo: string;
   mapaudio: string;
   audio: boolean;
   debug: boolean;
+  debugReturn: boolean;
 };

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -269,12 +269,20 @@ export class StreamingDelegate implements CameraStreamingDelegate {
 
     const resolution = this.determineResolution(request.video, this.videoConfig.forceMax);
 
-    const fps = (this.videoConfig.forceMax && this.videoConfig.maxFPS) ||
+    let fps = (this.videoConfig.forceMax && this.videoConfig.maxFPS) ||
       (request.video.fps > this.videoConfig.maxFPS) ?
       this.videoConfig.maxFPS : request.video.fps;
-    const videoBitrate = (this.videoConfig.forceMax && this.videoConfig.maxBitrate) ||
+    let videoBitrate = (this.videoConfig.forceMax && this.videoConfig.maxBitrate) ||
       (request.video.max_bit_rate > this.videoConfig.maxBitrate) ?
       this.videoConfig.maxBitrate : request.video.max_bit_rate;
+
+    if (vcodec === 'copy') {
+      resolution.width = 0;
+      resolution.height = 0;
+      resolution.videoFilter = '';
+      fps = 0;
+      videoBitrate = 0;
+    }
 
     this.log.debug('Video stream requested: ' + request.video.width + ' x ' + request.video.height + ', ' +
       request.video.fps + ' fps, ' + request.video.max_bit_rate + ' kbps', this.name, this.videoConfig.debug);
@@ -292,7 +300,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
       (fps > 0 ? ' -r ' + fps : '') +
       ' -f rawvideo' +
       ' ' + additionalCommandline +
-      (vcodec !== 'copy' && resolution.videoFilter ? ' -filter:v ' + resolution.videoFilter : '') +
+      (resolution.videoFilter.length > 0 ? ' -filter:v ' + resolution.videoFilter : '') +
       (videoBitrate > 0 ? ' -b:v ' + videoBitrate + 'k' : '') +
       ' -payload_type ' + request.video.pt;
 


### PR DESCRIPTION
### Changes

- This plugin now includes __experimental__ two-way audio support. Be aware that this feature is likely to be tweaked in the future, and a configuration that works now may need to be altered in the future.
- Better detection of audio and video streams. There should be very few scenarios where `mapvideo` or `mapaudio` are needed anymore, as FFmpeg's stream auto-selection is now set up.
- Default `videoFilter` can be disabled by including `none` in your comma-delimited list of filters.
- Further reorganization of the config UI.

### Bug Fixes

- Corrected handling of inactive camera timeouts. You should no longer see timeout messages after cleanly closing a camera stream.
- Fixed `forceMax` not applying to resolution in some scenarios.

### Breaking Changes

- `additionalCommandline` has been replaced by `encoderOptions` to better reflect it's intended use.
- `preserveRatio` has been removed and is now active as long as the default `videoFilter` list is active.