### PR TITLE
Add support for specifying the UUID of the accessory in the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Other users have been sharing configurations that work for them on our GitHub si
 - `serialNumber`: Set the serial number for display in the Home app. (Default: `SerialNumber`)
 - `firmwareRevision`: Set the firmware revision for display in the Home app. (Default: current plugin version)
 - `unbridge`: Bridged cameras can cause slowdowns of the entire Homebridge instance. If unbridged, the camera will need to be added to HomeKit manually. (Default: `false`)
+- `uuid`: Set the accessory UUID. If unspecified, the camera name will be used to generate a UUID. This enables you to have cameras with the same name across different rooms.
 
 #### Config Example with Manufacturer and Model Set
 

--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -14,6 +14,7 @@ export type FfmpegPlatformConfig = {
 
 export type CameraConfig = {
   name: string;
+  uuid: string;
   manufacturer: string;
   model: string;
   serialNumber: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,10 +67,17 @@ class FfmpegPlatform implements DynamicPlatformPlugin {
         }
 
         if (!error) {
-          const uuid = hap.uuid.generate(cameraConfig.name);
+          var uuid;
+          if (cameraConfig.uuid) {
+            uuid = cameraConfig.uuid;
+            this.log.debug('Used provided accessory UUID (' + uuid + ').', cameraConfig.name);
+          } else {
+            uuid = hap.uuid.generate(cameraConfig.name);
+            this.log.info('Used name to generate the accessory UUID (' + uuid + ').', cameraConfig.name);
+          }
           if (this.cameraConfigs.has(uuid)) {
-            // Camera names must be unique
-            this.log.warn('Multiple cameras are configured with this name. Duplicate cameras will be skipped.', cameraConfig.name);
+            // uuid must be unique
+            this.log.warn('Multiple accessories are configured with the same UUID. Duplicate cameras will be skipped.', cameraConfig.name);
           } else {
             this.cameraConfigs.set(uuid, cameraConfig);
           }
@@ -262,7 +269,7 @@ class FfmpegPlatform implements DynamicPlatformPlugin {
 
   private automationHandler(fullpath: string, name: string): AutomationReturn {
     const accessory = this.accessories.find((curAcc: PlatformAccessory) => {
-      return curAcc.displayName == name;
+      return curAcc.displayName == name || curAcc.UUID == name;
     });
     if (accessory) {
       const path = fullpath.split('/').filter((value) => value.length > 0);


### PR DESCRIPTION
The accessory UUID is currently being generated from the name of the camera and this has 2 problems: (1) makes it impossible to have cameras with the same name and (2) causes all setup in the Home app to be lost if the name is changed (scenes, automations, room assignments, favorites).
This change introduces a new parameter in the camera setup that is used to generate the the accessory UUID instead of the name.