### PR TITLE
Show error message on socket error

### DIFF
--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -409,7 +409,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
 
       activeSession.socket = createSocket(sessionInfo.ipv6 ? 'udp6' : 'udp4');
       activeSession.socket.on('error', (err: Error) => {
-        this.log.error('Socket error: ' + err.name, this.cameraName);
+        this.log.error('Socket error: ' + err.message, this.cameraName);
         this.stopStream(request.sessionID);
       });
       activeSession.socket.on('message', () => {


### PR DESCRIPTION
`err.name` would just return `Error` whereas `err.message`  would return `bind EACCES 0.0.0.0:57431`

RE: https://github.com/Sunoo/homebridge-camera-ffmpeg/issues/1087