### PR TITLE
Added graceful termination of rtsp stream

### DIFF
--- a/src/ffmpeg.ts
+++ b/src/ffmpeg.ts
@@ -72,7 +72,9 @@ export class FfmpegProcess {
     this.process.on('exit', (code: number, signal: NodeJS.Signals) => {
       const message = 'FFmpeg exited with code: ' + code + ' and signal: ' + signal;
 
-      if (code == null || code === 255) {
+      if (code == 0) {
+          log.debug(message + ' (Graceful)', cameraName, debug);
+      } else if (code == null || code === 255) {
         if (this.process.killed) {
           log.debug(message + ' (Expected)', cameraName, debug);
         } else {
@@ -123,7 +125,7 @@ export class FfmpegProcess {
   }
 
   public stop(): void {
-    this.process.kill('SIGKILL');
+    this.process.stdin.write("q\r\n"); 
   }
 
   public getStdin(): Writable {


### PR DESCRIPTION
Fixed reconnection problem for rtsp stream. Stream was killed and not gracefully shut down. This was a problem for at least Reolink cameras. With the fix, my Reolink camera is working reliable with this plugin.
 
see https://github.com/Sunoo/homebridge-camera-ffmpeg/issues/1134