### PR TITLE
Add support for two-way audio for SIP based video doorbell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,9 @@
       "dependencies": {
         "ffmpeg-for-homebridge": "^0.0.9",
         "mqtt": "4.2.8",
-        "pick-port": "^1.0.0"
+        "pick-port": "^1.0.0",
+        "sdp": "3.0.3",
+        "sip": "0.0.6"
       },
       "devDependencies": {
         "@types/node": "^17.0.5",
@@ -158,9 +160,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
-      "integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -419,6 +421,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -2417,6 +2424,11 @@
         }
       ]
     },
+    "node_modules/sdp": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.0.3.tgz",
+      "integrity": "sha512-8EkfckS+XZQaPLyChu4ey7PghrdcraCVNpJe2Gfdi2ON1ylQ7OasuKX+b37R9slnRChwIAiQgt+oj8xXGD8x+A=="
+    },
     "node_modules/semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -2494,6 +2506,25 @@
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/sip": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/sip/-/sip-0.0.6.tgz",
+      "integrity": "sha512-t+FYic4EQ25GTsIRWFVvsq+GmVkoZhrcoghANlnN6CsWMHGcfjPDYMD+nTBNrHR/WnRykF4nqx4i+gahAnW5NA==",
+      "dependencies": {
+        "ws": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=0.2.2"
+      }
+    },
+    "node_modules/sip/node_modules/ws": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/slash": {
@@ -2974,9 +3005,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
-      "integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==",
       "dev": true
     },
     "@types/ws": {
@@ -3134,6 +3165,11 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -4577,6 +4613,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
+    "sdp": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.0.3.tgz",
+      "integrity": "sha512-8EkfckS+XZQaPLyChu4ey7PghrdcraCVNpJe2Gfdi2ON1ylQ7OasuKX+b37R9slnRChwIAiQgt+oj8xXGD8x+A=="
+    },
     "semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -4625,6 +4666,24 @@
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "sip": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/sip/-/sip-0.0.6.tgz",
+      "integrity": "sha512-t+FYic4EQ25GTsIRWFVvsq+GmVkoZhrcoghANlnN6CsWMHGcfjPDYMD+nTBNrHR/WnRykF4nqx4i+gahAnW5NA==",
+      "requires": {
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+          "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
       }
     },
     "slash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       ],
       "license": "ISC",
       "dependencies": {
+        "@homebridge/camera-utils": "^2.0.4",
         "ffmpeg-for-homebridge": "^0.0.9",
         "mqtt": "4.2.8",
         "pick-port": "^1.0.0",
@@ -75,6 +76,18 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/@homebridge/camera-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@homebridge/camera-utils/-/camera-utils-2.0.4.tgz",
+      "integrity": "sha512-uR9RfnFGptSiEZaSnkSsQ1LPJarKyjVvHERzSXlK+P6Jui5T2yYgPKYvM+HBIpS8Kx3cfN5NBmQxhvm/qbD0IA==",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "ffmpeg-for-homebridge": "^0.0.9",
+        "pick-port": "^1.0.0",
+        "rxjs": "^7.3.0",
+        "systeminformation": "^5.8.0"
       }
     },
     "node_modules/@homebridge/ciao": {
@@ -640,7 +653,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1098,6 +1110,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1287,6 +1321,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -1481,6 +1526,14 @@
       "bin": {
         "homebridge": "bin/homebridge"
       },
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
         "node": ">=10.17.0"
       }
@@ -1743,6 +1796,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -1835,8 +1899,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -1913,6 +1976,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1933,6 +2001,14 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/mimic-response": {
@@ -2087,6 +2163,17 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
@@ -2147,6 +2234,20 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -2188,7 +2289,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2405,6 +2505,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.2.tgz",
+      "integrity": "sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2448,7 +2556,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -2460,7 +2567,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2478,6 +2584,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
+      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -2614,6 +2725,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2636,6 +2755,31 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/systeminformation": {
+      "version": "5.10.3",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.10.3.tgz",
+      "integrity": "sha512-qHYF5YwmhomGpKCZxWLgSt2eui/g5NQsqOixBrGmq1hdXFmurjdH6R5AwmFo7gCpQQpPEjd6Og6I6QzVKDzhKA==",
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "sunos",
+        "android"
+      ],
+      "bin": {
+        "systeminformation": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "Buy me a coffee",
+        "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
     "node_modules/tar": {
@@ -2681,8 +2825,7 @@
     "node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -2801,7 +2944,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -2935,6 +3077,18 @@
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         }
+      }
+    },
+    "@homebridge/camera-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@homebridge/camera-utils/-/camera-utils-2.0.4.tgz",
+      "integrity": "sha512-uR9RfnFGptSiEZaSnkSsQ1LPJarKyjVvHERzSXlK+P6Jui5T2yYgPKYvM+HBIpS8Kx3cfN5NBmQxhvm/qbD0IA==",
+      "requires": {
+        "execa": "^5.1.1",
+        "ffmpeg-for-homebridge": "^0.0.9",
+        "pick-port": "^1.0.0",
+        "rxjs": "^7.3.0",
+        "systeminformation": "^5.8.0"
       }
     },
     "@homebridge/ciao": {
@@ -3323,7 +3477,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3670,6 +3823,22 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3832,6 +4001,11 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+    },
     "get-symbol-description": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -3970,6 +4144,11 @@
         "semver": "^7.3.5",
         "source-map-support": "^0.5.20"
       }
+    },
+    "human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
     "ieee754": {
       "version": "1.2.1",
@@ -4137,6 +4316,11 @@
       "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
       "dev": true
     },
+    "is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+    },
     "is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -4202,8 +4386,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -4266,6 +4449,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4281,6 +4469,11 @@
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
       }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "2.1.0",
@@ -4401,6 +4594,14 @@
         }
       }
     },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "requires": {
+        "path-key": "^3.0.0"
+      }
+    },
     "object-inspect": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
@@ -4443,6 +4644,14 @@
         "wrappy": "1"
       }
     },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -4474,8 +4683,7 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-type": {
       "version": "4.0.0",
@@ -4608,6 +4816,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "rxjs": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.2.tgz",
+      "integrity": "sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4631,7 +4847,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -4639,8 +4854,7 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "side-channel": {
       "version": "1.0.4",
@@ -4652,6 +4866,11 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "signal-exit": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
+      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
     },
     "simple-concat": {
       "version": "1.0.1",
@@ -4758,6 +4977,11 @@
         "ansi-regex": "^5.0.1"
       }
     },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4772,6 +4996,11 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
+    },
+    "systeminformation": {
+      "version": "5.10.3",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.10.3.tgz",
+      "integrity": "sha512-qHYF5YwmhomGpKCZxWLgSt2eui/g5NQsqOixBrGmq1hdXFmurjdH6R5AwmFo7gCpQQpPEjd6Og6I6QzVKDzhKA=="
     },
     "tar": {
       "version": "6.1.10",
@@ -4810,8 +5039,7 @@
     "tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -4904,7 +5132,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
+    "@homebridge/camera-utils": "^2.0.4",
     "ffmpeg-for-homebridge": "^0.0.9",
     "mqtt": "4.2.8",
     "pick-port": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
   "dependencies": {
     "ffmpeg-for-homebridge": "^0.0.9",
     "mqtt": "4.2.8",
-    "pick-port": "^1.0.0"
+    "pick-port": "^1.0.0",
+    "sdp": "3.0.3",
+    "sip": "0.0.6"
   }
 }

--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -28,6 +28,7 @@ export type CameraConfig = {
   mqtt?: MqttCameraConfig;
   unbridge?: boolean;
   videoConfig?: VideoConfig;
+  sipConfig?: SipConfig;
 };
 
 export type VideoConfig = {
@@ -58,4 +59,9 @@ export type MqttCameraConfig = {
   motionResetMessage?: string;
   doorbellTopic?: string;
   doorbellMessage?: string;
+};
+
+export type SipConfig = {
+  from: string;
+  to: string;
 };

--- a/src/rtp.ts
+++ b/src/rtp.ts
@@ -1,0 +1,147 @@
+import { Logger } from "./logger";
+import { createSocket, RemoteInfo, Socket } from "dgram";
+
+export class RtpHelper {
+  private readonly logPrefix: string;
+  private readonly log: Logger;
+  private heartbeatTimer!: NodeJS.Timeout;
+  private heartbeatMsg!: Buffer;
+  private inputPort: number;
+  private inputRtcpPort: number;
+  public readonly rtpSocket: Socket;
+  public readonly rtcpSocket?: Socket;
+
+  // Create an instance of RtpHelper.
+  constructor(log: Logger, logPrefix: string, ipFamily: ("ipv4" | "ipv6") , inputPort: number, inputRtcpPort: number, rtcpPort: number, rtpPort: number, 
+                                                                            sendAddress: string, sendPort: number, sendRtcpPort: number) {
+
+    this.log = log;
+    this.logPrefix = logPrefix;
+    this.inputPort = inputPort;
+    this.inputRtcpPort = inputRtcpPort;
+    this.rtpSocket = createSocket(ipFamily === "ipv6" ? "udp6" : "udp4" );
+    this.rtcpSocket = (inputPort !== inputRtcpPort) ? createSocket(ipFamily === "ipv6" ? "udp6" : "udp4" ) : undefined;
+
+    // Catch errors when they happen on our demuxer.
+    this.rtpSocket.on("error", (error)  => {
+      this.log.error("RtpHelper (RTP) Error: " + error, this.logPrefix);
+      this.rtpSocket.close();
+    });
+
+    // Catch errors when they happen on our demuxer.
+    this.rtcpSocket?.on("error", (error)  => {
+        this.log.error("RtpHelper (RTCP) Error: " + error, this.logPrefix);
+        this.rtcpSocket?.close();
+    });
+      
+    // Split the message into RTP and RTCP packets.
+    this.rtpSocket.on("message", (msg: Buffer, rinfo: RemoteInfo) => {
+
+      // Check if we have to forward a packet from ffmpeg to the external peer
+      if (rinfo.address === '127.0.0.1')
+      {
+        this.rtpSocket.send(msg, sendPort, sendAddress);
+        return;
+      }
+
+      // Send RTP packets to the RTP port.
+      if(this.isRtpMessage(msg)) {
+
+        this.rtpSocket.send(msg, rtpPort);
+
+      } else {
+
+        // Save this RTCP message for heartbeat purposes for the RTP port. This works because RTCP packets will be ignored
+        // by ffmpeg on the RTP port, effectively providing a heartbeat to ensure FFmpeg doesn't timeout if there's an
+        // extended delay between data transmission.
+        //this.heartbeatMsg = Buffer.from(msg);
+
+        // Clear the old heartbeat timer.
+        //clearTimeout(this.heartbeatTimer);
+        //this.heartbeat(rtpPort);
+
+        // RTCP control packets should go to the RTCP port.
+        this.rtpSocket.send(msg, rtcpPort);
+
+      }
+    });
+
+    // Split the message into RTP and RTCP packets.
+    this.rtcpSocket?.on("message", (msg: Buffer, rinfo: RemoteInfo) => {
+
+        // Check if we have to forward a packet from ffmpeg to the external peer
+        if (rinfo.address === '127.0.0.1')
+        {
+            this.rtcpSocket?.send(msg, sendRtcpPort, sendAddress);
+            return;
+        }
+    
+        // Send RTP packets to the RTP port.
+        if(this.isRtpMessage(msg)) {
+    
+            this.rtcpSocket?.send(msg, rtpPort);
+    
+        } else {
+    
+            // Save this RTCP message for heartbeat purposes for the RTP port. This works because RTCP packets will be ignored
+            // by ffmpeg on the RTP port, effectively providing a heartbeat to ensure FFmpeg doesn't timeout if there's an
+            // extended delay between data transmission.
+            //this.heartbeatMsg = Buffer.from(msg);
+    
+            // Clear the old heartbeat timer.
+            //clearTimeout(this.heartbeatTimer);
+            //this.heartbeat(rtpPort);
+    
+            // RTCP control packets should go to the RTCP port.
+            this.rtcpSocket?.send(msg, rtcpPort);
+    
+        }
+    });
+      
+    this.log.debug("Creating RtpHelper instance - inbound port: " + this.inputPort + ", RTCP port: " + rtcpPort + ", RTP port: " + rtpPort, this.logPrefix);
+
+    // Take the socket live.
+    this.rtpSocket.bind(this.inputPort);
+    this.rtcpSocket?.bind(this.inputRtcpPort);
+  }
+
+  // Send a regular heartbeat to FFmpeg to ensure the pipe remains open and the process alive.
+  private heartbeat(port: number): void {
+
+    // Clear the old heartbeat timer.
+    clearTimeout(this.heartbeatTimer);
+
+    // Send a heartbeat to FFmpeg every few seconds to keep things open. FFmpeg has a five-second timeout
+    // in reading input, and we want to be comfortably within the margin for error to ensure the process
+    // continues to run.
+    this.heartbeatTimer = setTimeout(() => {
+
+      this.log.debug("Sending ffmpeg a heartbeat.", this.logPrefix);
+
+      this.rtpSocket.send(this.heartbeatMsg, port);
+      this.heartbeat(port);
+
+    }, 3.5 * 1000);
+  }
+
+  // Close the socket and cleanup.
+  public close(): void {
+    this.log.debug("Closing RtpHelper instance on port: " + this.inputPort, this.logPrefix);
+
+    //clearTimeout(this.heartbeatTimer);
+    this.rtpSocket.close();
+    this.rtcpSocket?.close();
+  }
+
+  // Retrieve the payload information from a packet to discern what the packet payload is.
+  private getPayloadType(message: Buffer): number {
+    return message.readUInt8(1) & 0x7f;
+  }
+
+  // Return whether or not a packet is RTP (or not).
+  private isRtpMessage(message: Buffer): boolean {
+    const payloadType = this.getPayloadType(message);
+
+    return (payloadType > 90) || (payloadType === 0);
+  }
+}

--- a/src/sip-call.ts
+++ b/src/sip-call.ts
@@ -21,7 +21,7 @@ export interface RtpDescription {
 export interface SipOptions {
   to: string
   from: string
-  localIp: string
+  //localIp: string
 }
 
 interface UriOptions {
@@ -85,7 +85,7 @@ function getRtpDescription(
 
     return {
       port,
-      rtcpPort: (rtcpLine && Number(rtcpLine.match(/rtcp:(\S*)/)?.[1])) || port+1,
+      rtcpPort: (rtcpLine && Number(rtcpLine.match(/rtcp:(\S*)/)?.[1])) || port + 1, // if there is no explicit RTCP port, then use RTP port + 1
       ssrc:     (ssrcLine && Number(ssrcLine.match(/ssrc:(\S*)/)?.[1])) || undefined
     }
   } catch (e) {
@@ -123,9 +123,11 @@ export class SipCall {
     private sipOptions: SipOptions,
   ) {
     this.log = log;
-    const { from } = this.sipOptions,
-            host = this.sipOptions.localIp
+    const fromUri = sip.parseUri(this.sipOptions.from);
+    const host = fromUri.host;
 
+    const { from } = this.sipOptions
+            //host = this.sipOptions.localIp
     this.sipStack = {
       makeResponse: sip.makeResponse, 
       ...sip.create({
@@ -247,9 +249,11 @@ export class SipCall {
     this.callId = getRandomId();
     this.toParams.tag = undefined;
 
+    const fromUri = sip.parseUri(this.sipOptions.from);
+    const host = fromUri.host;    
     const { audio } = rtpOptions,
-          { from } = this.sipOptions,
-            host = this.sipOptions.localIp;
+          { from } = this.sipOptions
+            //host = this.sipOptions.localIp;
 
     const sdp = ([
       'v=0',

--- a/src/sip-call.ts
+++ b/src/sip-call.ts
@@ -1,0 +1,291 @@
+//import { noop, Subject } from 'rxjs'
+import { Logger } from './logger';
+
+const sip = require('sip'),
+      sdp = require('sdp')
+
+export interface RtpStreamOptions {
+  port: number
+  rtcpPort: number
+  ssrc?: number
+}
+
+export interface RtpOptions {
+  audio: RtpStreamOptions
+}
+
+export interface RtpDescription {
+  address: string
+  audio: RtpStreamOptions
+}
+
+interface UriOptions {
+  name?: string
+  uri: string
+  params?: { tag?: string }
+}
+
+interface SipHeaders {
+  [name: string]: string | any
+  cseq: { seq: number; method: string }
+  to: UriOptions
+  from: UriOptions
+  contact?: UriOptions[]
+  via?: UriOptions[]
+}
+
+export interface SipRequest {
+  uri: UriOptions | string
+  method: string
+  headers: SipHeaders
+  content: string
+}
+
+export interface SipResponse {
+  status: number
+  reason: string
+  headers: SipHeaders
+  content: string
+}
+
+export interface SipClient {
+  send: (
+    request: SipRequest | SipResponse,
+    handler?: (response: SipResponse) => void
+  ) => void
+  destroy: () => void
+  makeResponse: (
+    response: SipRequest,
+    status: number,
+    method: string
+  ) => SipResponse
+}
+
+export interface SipOptions {
+  to: string
+  from: string
+  localIp: string
+}
+
+function getRandomId() {
+  return Math.floor(Math.random() * 1e6).toString()
+}
+
+function getRtpDescription(
+  log: Logger,
+  sections: string[],
+  mediaType: 'audio'
+): RtpStreamOptions {
+  try {
+    const section = sections.find((s) => s.startsWith('m=' + mediaType))
+
+    const { port } = sdp.parseMLine(section),
+    lines: string[] = sdp.splitLines(section),
+    rtcpLine = lines.find((l: string) => l.startsWith('a=rtcp:')),
+    ssrcLine = lines.find((l: string) => l.startsWith('a=ssrc'))
+
+    return {
+      port,
+      rtcpPort: (rtcpLine && Number(rtcpLine.match(/rtcp:(\S*)/)?.[1])) || port+1,
+      ssrc:     (ssrcLine && Number(ssrcLine.match(/ssrc:(\S*)/)?.[1])) || undefined
+    }
+  } catch (e) {
+    log.error('Failed to parse SDP from remote end')
+    log.error(sections.join('\r\n'))
+    throw e
+  }
+}
+
+function parseRtpDescription(log: Logger, inviteResponse: {
+  content: string
+}): RtpDescription {
+  const sections: string[] = sdp.splitSections(inviteResponse.content),
+    lines: string[] = sdp.splitLines(sections[0]),
+    cLine = lines.find((line: string) => line.startsWith('c='))!
+
+  return {
+    address: cLine.match(/c=IN IP4 (\S*)/)![1],
+    audio: getRtpDescription(log, sections, 'audio')
+  }
+}
+
+export class SipCall {
+  private seq = 20
+  private fromParams = { tag: getRandomId() }
+  private toParams: { tag?: string } = {}
+  private callId = getRandomId()
+  private sipClient: SipClient
+  //public readonly onEndedByRemote = new Subject()
+  private destroyed = false
+  private readonly log: Logger
+
+  public readonly sdp: string
+
+  constructor(
+    log: Logger,
+    private sipOptions: SipOptions,
+    rtpOptions: RtpOptions,
+  ) {
+    this.log = log;
+    const { audio } = rtpOptions,
+          { from } = this.sipOptions,
+          host = this.sipOptions.localIp
+
+    this.sipClient = {
+      makeResponse: sip.makeResponse, 
+      ...sip.create({
+        host,
+        hostname: host,
+        tcp: false,
+        udp: true,
+      },
+      (request: SipRequest) => {
+        if (request.method === 'BYE') {
+          this.log.info('received BYE from remote end')
+          this.sipClient.send(this.sipClient.makeResponse(request, 200, 'Ok'))
+
+          if (this.destroyed) {
+            //this.onEndedByRemote.next(null)
+          }
+        } 
+      }
+    )}
+
+    this.sdp = [
+      'v=0',
+      `o=${from.split(':')[1].split('@')[0]} 3747 461 IN IP4 ${host}`,
+      's=Talk',
+      `c=IN IP4 ${host}`,
+      't=0 0',
+      `m=audio ${audio.port} RTP/AVP 0`,
+      'a=rtpmap:0 PCMU/8000',
+      `a=rtcp:${audio.rtcpPort}`,
+      'a=ssrc:2315747900',
+      'a=sendrecv'
+    ]
+      .filter((l) => l)
+      .join('\r\n')
+    this.sdp = this.sdp += '\r\n'
+  }
+
+  request({
+    method,
+    headers,
+    content,
+    seq,
+  }: {
+    method: string
+    headers?: Partial<SipHeaders>
+    content?: string
+    seq?: number
+  }) {
+    if (this.destroyed) {
+      return Promise.reject(
+        new Error('SIP request made after call was destroyed')
+      )
+    }
+
+    return new Promise<SipResponse>((resolve, reject) => {
+      seq = seq || this.seq++
+      this.sipClient.send(
+        {
+          method,
+          uri: this.sipOptions.to,
+          headers: {
+            to: {
+              name: '"SIP doorbell client"',
+              uri: this.sipOptions.to,
+              params: this.toParams,
+            },
+            from: {
+              uri: this.sipOptions.from,
+              params: this.fromParams,
+            },
+            'max-forwards': 70,
+            'call-id': this.callId,
+            cseq: { seq, method },
+            ...headers,
+          },
+          content: content || '',
+        },
+        (response: SipResponse) => {
+          if (response.headers.to.params && response.headers.to.params.tag) {
+            this.toParams.tag = response.headers.to.params.tag
+          }
+
+          if (response.status >= 300) {
+            if (response.status !== 408 || method !== 'BYE') {
+              this.log.error(
+                `sip ${method} request failed with status ` + response.status
+              )
+            }
+            reject(
+              new Error(
+                `sip ${method} request failed with status ` + response.status
+              )
+            )
+          } else if (response.status < 200) {
+            // call made progress, do nothing and wait for another response
+            // console.log('call progress status ' + response.status)
+          } else {
+            if (method === 'INVITE') {
+              // The ACK must be sent with every OK to keep the connection alive.
+              this.ackWithInfo(seq!).catch((e) => {
+                this.log.error('Failed to send SDP ACK and INFO')
+                this.log.error(e)
+              })
+            }
+            resolve(response)
+          }
+        }
+      )
+    })
+  }
+
+  private async ackWithInfo(seq: number) {
+    // Don't wait for ack, it won't ever come back.
+    this.request({
+      method: 'ACK',
+      seq, // The ACK must have the original sequence number.
+    //}).catch(noop)
+    }).catch()
+  }
+
+  sendDtmf(key: string) {
+    return this.request({
+      method: 'INFO',
+      headers: {
+        'Content-Type': 'application/dtmf-relay',
+      },
+      content: `Signal=${key}\r\nDuration=250`,
+    })
+  }
+
+  async invite() {
+    const { from } = this.sipOptions,
+      inviteResponse = await this.request({
+        method: 'INVITE',
+        headers: {
+          supported: 'replaces, outbound',
+          allow:
+            'INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY, MESSAGE, SUBSCRIBE, INFO, UPDATE',
+          'content-type': 'application/sdp',
+          contact: [{ uri: from }],
+        },
+        content: this.sdp,
+      })
+
+    return parseRtpDescription(this.log, inviteResponse)
+  }
+
+  sendBye() {
+    return this.request({ method: 'BYE' }).catch(() => {
+      // Don't care if we get an exception here.
+    })
+  }
+
+  destroy() {
+    this.destroyed = true
+    this.sipClient.destroy()
+  }
+}

--- a/src/sip-call.ts
+++ b/src/sip-call.ts
@@ -21,7 +21,6 @@ export interface RtpDescription {
 export interface SipOptions {
   to: string
   from: string
-  //localIp: string
 }
 
 interface UriOptions {
@@ -125,14 +124,15 @@ export class SipCall {
     this.log = log;
     const fromUri = sip.parseUri(this.sipOptions.from);
     const host = fromUri.host;
+    const port = fromUri.port;
 
     const { from } = this.sipOptions
-            //host = this.sipOptions.localIp
     this.sipStack = {
       makeResponse: sip.makeResponse, 
       ...sip.create({
         host,
         hostname: host,
+        port: port,
         udp: true,
         tcp: false,
         tls: false,
@@ -253,7 +253,6 @@ export class SipCall {
     const host = fromUri.host;    
     const { audio } = rtpOptions,
           { from } = this.sipOptions
-            //host = this.sipOptions.localIp;
 
     const sdp = ([
       'v=0',

--- a/src/sip-call.ts
+++ b/src/sip-call.ts
@@ -141,10 +141,8 @@ export class SipCall {
           this.log.info('received BYE from remote end')
           this.sipStack.send(this.sipStack.makeResponse(request, 200, 'Ok'))
 
-          if (this.destroyed) {
-            if (this.onEndedByRemote) {
-              this.onEndedByRemote()
-            }
+          if (this.onEndedByRemote) {
+            this.onEndedByRemote()
           }
         } 
       }
@@ -244,6 +242,10 @@ export class SipCall {
   }
 
   async invite(rtpOptions: RtpOptions) {
+
+    // As we keep the SIP stack alive, we havw to reset call-related properties for each new call
+    this.callId = getRandomId();
+    this.toParams.tag = undefined;
 
     const { audio } = rtpOptions,
           { from } = this.sipOptions,

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -151,12 +151,8 @@ export class StreamingDelegate implements CameraStreamingDelegate {
 
     if (this.sipConfig) {
       this.sipCall = new SipCall(this.log, {
-          //to: "sip:11@10.10.10.80",
-          //to: "sip:11@10.10.10.22",
-          //from: "sip:user1@10.10.10.126",
           from: this.sipConfig.from,
           to: this.sipConfig.to
-          //localIp: "10.10.10.126",
       });
     }
 

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -332,7 +332,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
       audioReturnPort: audioReturnPort,
       audioCryptoSuite: request.audio.srtpCryptoSuite,
       audioSRTP: Buffer.concat([request.audio.srtp_key, request.audio.srtp_salt]),
-      audioSSRC: audioSSRC,
+      audioSSRC: audioSSRC
     };
  
     if (this.sipConfig && this.sipCall) {
@@ -340,7 +340,9 @@ export class StreamingDelegate implements CameraStreamingDelegate {
         sipIncomingAudioPort,
         sipIncomingAudioRtcpPort
         ] = await reservePorts({count: 2, type: 'udp'});
-      const sipAudioSSRC = this.hap.CameraController.generateSynchronisationSource(); // The current implementation just seems to generate a random number. No additional magic inside. So just use it.
+      // The current implementation of generateSynchronisationSource() just seems to generate a random number.
+      // No additional magic inside. So just use it for our SIP signaling too.
+      const sipAudioSSRC = this.hap.CameraController.generateSynchronisationSource(); 
   
       const [sipLocalAudioPort, sipLocalAudioRtcpPort] = await reservePorts({count: 2, type: 'udp'});
   


### PR DESCRIPTION
Hi!

This PR addresses this issue https://github.com/Sunoo/homebridge-camera-ffmpeg/issues/928.

It adds support for two-way audio between Homekit and a SIP-based video doorbell.
Those video doorbells based on SIP seem to exist in at least two different flavours:

1. Video is a completely seperate thing: e.g. MJPEG stream via HTTP only. SIP is only used for Audio.
2. Video is a H264 stream that is also negotiated as an additional stream (next to Audio) during SIP signaling.

This PR only addresses variant 1). However, adding variant 2) should not be too difficult.

The solution presented here does not involve using audio devices (e.g. alsa loopback) or the like and it does not use an external SIP softphone to handle the SIP call.
It uses the well-known [SIP stack from kirm](https://github.com/kirm/sip.js/). 

The SIP call is a direct SIP call between two peers. No proxy or registrar is involved.
A SIP INVITE is sent with the suggested RTP stream and codec parameters (SDP) and the related SIP response SDP from the video doorbell is parsed.
Based on these two SDPs the two FFmpeg instances are configured accordingly.
As a result the SIP video doorbell sends and receives the audio streams directly to/from the homebridge-camera-ffmpeg plugin (two ffmpeg instances). Full-Duplex.

For now the negotiated codec towards the SIP doorbell is hard-coded to G.711 (u-Law). All SIP devices should support this codec. For example, my doorbell only supports G.711 u-Law and A-law.

At the following to your camera config:
```
                  "sipConfig": {
                        "to": "sip:11@10.10.10.22",
                        "from": "sip:user1@10.10.10.126"
                    }
```

A big thank you goes to this project: https://github.com/dgreif/ring
The Ring cameras speak SIP towards the Ring servers. So I learned all the basics from dgreifs solution.

The RTPhelper was inspired by this project: https://github.com/hjdhjd/homebridge-unifi-protect

The RTPhelper is necessary as my SIP doorbell requires [symmetric RTP](https://datatracker.ietf.org/doc/html/rfc4961). 
As having two FFmpeg instances receiving and sending on the same UDP port does not work, I had to create an additional helper socket for this. 
Without using symmetric RTP, my doorbell immediately stopped sending RTP audio when it started to receive RTP audio from some random port from FFmpeg.
