### PR TITLE
Config typeahead; add h264_v4l2m2m, rem h264_omx

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -197,7 +197,7 @@
                 "typeahead": {
                   "source": [
                     "libx264",
-                    "h264_omx",
+                    "h264_v4l2m2m",
                     "h264_videotoolbox",
                     "copy"
                   ]


### PR DESCRIPTION
This change will modify the list of suggested codecs in the Homebridge Config typeahead dropdown. It adds `"h264_v4l2m2m"` and removes `"h264_omx"`.  h264_omx was deprecated in Raspberry Pi OS v. Bullseye.

reference: https://forums.raspberrypi.com/viewtopic.php?p=1977798&hilit=h264_omx#p1935358