### PR TITLE
Feat/ffmpeg motion detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,143 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Homebridge plugin that provides FFmpeg-based camera support for Apple HomeKit. It enables IP cameras to be integrated into HomeKit with support for video streaming, snapshots, motion detection, doorbell functionality, and HomeKit Secure Video recording.
+
+## Development Commands
+
+### Essential Commands
+- `npm run build` - Compile TypeScript to JavaScript (outputs to `dist/`)
+- `npm run lint` - Run ESLint on source files
+- `npm run lint:fix` - Auto-fix linting issues
+- `npm test` - Run all tests with Vitest
+- `npm run test:watch` - Run tests in watch mode
+- `npm run test-coverage` - Run tests with coverage report
+- `npm run clean` - Remove the dist folder
+
+### Development Workflow
+- `npm run watch` - Build, copy plugin UI files, link locally, and watch for changes with nodemon
+- `npm run plugin-ui` - Copy Homebridge UI files from `src/homebridge-ui/public/` to `dist/homebridge-ui/public/`
+
+### Note on Testing
+The project uses Vitest for testing. Test files are excluded from the TypeScript compilation (see `tsconfig.json`).
+
+## Architecture Overview
+
+### Core Components
+
+**Platform (platform.ts)**
+- Entry point that registers with Homebridge as a dynamic platform plugin
+- Manages camera accessories lifecycle (creation, configuration, caching)
+- Handles automation integrations (MQTT client, HTTP server)
+- Routes motion/doorbell events to appropriate handlers
+- Maintains timers for motion/doorbell resets
+
+**Streaming Delegate (streamingDelegate.ts)**
+- Implements HomeKit camera streaming protocol
+- Manages video/audio RTP streams via FFmpeg
+- Handles snapshot requests (supports both HTTP URLs and FFmpeg extraction)
+- Coordinates session management (pending, ongoing, timeouts)
+- Creates and manages the recording delegate if HSV is enabled
+
+**Recording Delegate (recordingDelegate.ts)**
+- Implements HomeKit Secure Video (HSV) recording
+- Generates fragmented MP4 streams with proper H.264 profiles/levels
+- Handles recording configuration updates from HomeKit
+- Works with prebuffering to capture pre-motion video
+- Uses async generators to yield MP4 fragments (ftyp, moov, moof, mdat boxes)
+
+**PreBuffer (prebuffer.ts)**
+- Maintains a rolling buffer of recent video for HSV
+- Runs a persistent FFmpeg process that outputs fragmented MP4
+- Stores atoms with timestamps for time-based retrieval
+- Provides video segments on-demand when recording is triggered
+
+**FFmpeg Process (ffmpeg.ts)**
+- Wrapper around FFmpeg child processes
+- Parses progress output for monitoring
+- Handles process lifecycle (start, stop, error handling)
+- Supports motion detection via scene change analysis
+- Logs performance metrics and errors
+
+### Data Flow
+
+1. **Live Streaming**: HomeKit → StreamingDelegate → FFmpeg → RTP/SRTP stream
+2. **Snapshots**: HomeKit → StreamingDelegate → FFmpeg (or direct HTTP fetch) → JPEG
+3. **HSV Recording**: Motion event → RecordingDelegate → PreBuffer → FFmpeg → MP4 fragments → HomeKit
+4. **Motion Detection**: FFmpeg scene filter → FfmpegProcess callback → Platform motion handler
+5. **Automation**: MQTT/HTTP → Platform handlers → Update HomeKit characteristics
+
+### Key Design Patterns
+
+- **Delegate Pattern**: Streaming and recording delegates implement HomeKit protocols
+- **Session Management**: Maps track active streaming/recording sessions by session ID
+- **Async Generators**: Used for streaming MP4 atoms from FFmpeg output
+- **Event-based**: PreBuffer uses EventEmitter to notify consumers of new video atoms
+
+## Important Configuration Details
+
+### Camera Configuration Structure
+Cameras are configured in the platform config with these key sections:
+- `videoConfig.source` - FFmpeg input arguments (required, must include `-i`)
+- `videoConfig.subSource` - Lower resolution stream for motion detection
+- `videoConfig.stillImageSource` - Direct URL or FFmpeg source for snapshots
+- `videoConfig.recording` - Enables HomeKit Secure Video
+- `videoConfig.prebuffer` - Enables video prebuffering for HSV (requires recording)
+
+### FFmpeg Path Resolution
+The plugin uses this hierarchy for finding FFmpeg:
+1. `videoProcessor` from platform or camera config
+2. `defaultFfmpegPath` from `@homebridge/camera-utils` package
+3. System `ffmpeg` command
+
+### TypeScript Configuration
+- Target: ES2022 with ES Modules (`"type": "module"` in package.json)
+- Module resolution: bundler mode
+- Strict mode enabled, but `noImplicitAny` is disabled
+- Source maps and declarations generated
+
+## Working with This Codebase
+
+### Adding Features
+- Camera features require updates to: settings.ts (types), config.schema.json (UI), platform.ts or streamingDelegate.ts (logic)
+- HSV features primarily live in recordingDelegate.ts and prebuffer.ts
+- Motion/doorbell automation touches platform.ts event handlers and ffmpeg.ts for detection
+
+### Snapshot Fetching
+The plugin intelligently chooses between two methods for fetching snapshots:
+
+**Direct HTTP/HTTPS Fetch** (streamingDelegate.ts:fetchSnapshot)
+- Used when `stillImageSource` is a plain URL (matches `/^https?:\/\/[^\s]+$/`)
+- Fetches images directly using Node's native `http`/`https` modules
+- Much faster than FFmpeg (no process spawn overhead)
+- 10-second timeout with proper error handling
+- Example: `"stillImageSource": "http://192.168.1.100/snapshot.jpg"`
+
+**FFmpeg-based Fetch**
+- Used for RTSP streams or FFmpeg-style arguments
+- Required when video filters need to be applied
+- Handles complex sources that require decoding
+- Example: `"stillImageSource": "-i rtsp://192.168.1.100:554/stream"`
+
+The detection is automatic and transparent to the user.
+
+### FFmpeg Integration
+- All FFmpeg commands are split by whitespace and passed as argv arrays
+- Debug logging can be enabled per-camera via `videoConfig.debug`
+- FFmpeg processes output progress to stdout and logs to stderr
+- Scene-based motion detection uses the `select` filter with metadata output
+
+### Session Management
+Sessions have distinct lifecycle stages:
+- Pending: Created during prepareStream, stores crypto/network info
+- Ongoing: Active after startStream, contains FFmpeg processes and sockets
+- Cleanup: Happens on stopStream or controller.forceStopStreamingSession
+
+### Common Patterns
+- All camera names are required; the platform generates defaults if missing
+- UUID generation uses `api.hap.uuid.generate(cameraName)` for consistency
+- Services are removed and recreated on configuration changes (not updated in-place)
+- Accessories are published as external (unbridged by default) via `publishExternalAccessories`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ The project uses Vitest for testing. Test files are excluded from the TypeScript
 1. **Live Streaming**: HomeKit → StreamingDelegate → FFmpeg → RTP/SRTP stream
 2. **Snapshots**: HomeKit → StreamingDelegate → FFmpeg (or direct HTTP fetch) → JPEG
 3. **HSV Recording**: Motion event → RecordingDelegate → PreBuffer → FFmpeg → MP4 fragments → HomeKit
-4. **Motion Detection**: FFmpeg scene filter → FfmpegProcess callback → Platform motion handler
+4. **FFmpeg Motion Detection**: subSource stream → FFmpeg scene filter → Platform.startMotionDetection() → motionHandler() → HomeKit
 5. **Automation**: MQTT/HTTP → Platform handlers → Update HomeKit characteristics
 
 ### Key Design Patterns
@@ -132,6 +132,37 @@ The plugin intelligently chooses between two methods for fetching snapshots:
 - Example: `"stillImageSource": "-i rtsp://192.168.1.100:554/stream"`
 
 The detection is automatic and transparent to the user.
+
+### FFmpeg Motion Detection
+The plugin supports automatic motion detection by analyzing the video stream:
+
+**How It Works**
+- Uses FFmpeg's scene change detection filter (`select='gt(scene,threshold)'`)
+- Analyzes a lower-resolution stream (`subSource`) to reduce CPU usage
+- Triggers the existing motion sensor when significant scene changes are detected
+- Includes configurable sensitivity and cooldown periods
+
+**Configuration**
+- `ffmpegMotionDetection` (boolean) - Enables automatic motion detection
+- `ffmpegMotionSensitivity` (number, 0.01-0.1) - Threshold for scene changes (default: 0.03)
+  - Lower values = more sensitive
+  - Higher values = less sensitive
+- `videoConfig.subSource` (string) - Direct RTSP URL for motion analysis
+  - Example: `"rtsp://camera.local:554/sub"` (no `-i` prefix needed)
+  - Should be a lower resolution stream than main source
+- `motionTimeout` (seconds) - Reused for motion cooldown period (default: 15)
+
+**Implementation Details** (platform.ts)
+- Motion detection process runs independently from streaming
+- Auto-restarts on failure with 10-second delay
+- Scene scores are logged when motion is detected
+- Integrates with existing `motionHandler()` to trigger HomeKit notifications
+- Process lifecycle managed in `motionDetectionProcesses` Map
+
+**Requirements**
+- `motion: true` must be enabled (creates the motion sensor)
+- `videoConfig.subSource` must be configured
+- Camera must provide a sub stream URL
 
 ### FFmpeg Integration
 - All FFmpeg commands are split by whitespace and passed as argv arrays

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,8 @@ The plugin supports automatic motion detection by analyzing the video stream:
 - `ffmpegMotionSensitivity` (number, 0.01-0.1) - Threshold for scene changes (default: 0.03)
   - Lower values = more sensitive
   - Higher values = less sensitive
-- `videoConfig.subSource` (string) - Direct RTSP URL for motion analysis
-  - Example: `"rtsp://camera.local:554/sub"` (no `-i` prefix needed)
+- `videoConfig.subSource` (string) - FFmpeg arguments for motion analysis stream
+  - Same syntax as `source` (e.g., `"-rtsp_transport tcp -i rtsp://camera.local:554/sub"`)
   - Should be a lower resolution stream than main source
 - `motionTimeout` (seconds) - Reused for motion cooldown period (default: 15)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,11 +56,11 @@ The project uses Vitest for testing. Test files are excluded from the TypeScript
 - Provides video segments on-demand when recording is triggered
 
 **FFmpeg Process (ffmpeg.ts)**
-- Wrapper around FFmpeg child processes
+- Wrapper around FFmpeg child processes for video streaming
 - Parses progress output for monitoring
 - Handles process lifecycle (start, stop, error handling)
-- Supports motion detection via scene change analysis
 - Logs performance metrics and errors
+- Note: Motion detection FFmpeg processes are managed directly by Platform
 
 ### Data Flow
 
@@ -82,7 +82,10 @@ The project uses Vitest for testing. Test files are excluded from the TypeScript
 ### Camera Configuration Structure
 Cameras are configured in the platform config with these key sections:
 - `videoConfig.source` - FFmpeg input arguments (required, must include `-i`)
-- `videoConfig.subSource` - Lower resolution stream for motion detection
+  - Example: `"-rtsp_transport tcp -i rtsp://camera.local:554/stream0"`
+- `videoConfig.subSource` - FFmpeg input arguments for lower resolution stream (for motion detection)
+  - Same syntax as `source` (must include `-i`)
+  - Example: `"-rtsp_transport tcp -i rtsp://camera.local:554/stream1"`
 - `videoConfig.stillImageSource` - Direct URL or FFmpeg source for snapshots
   - HTTP/HTTPS URLs: `"http://camera.local/snapshot.jpg"` (no `-i` needed)
   - FFmpeg sources: `"-i rtsp://camera.local:554/stream"` (requires `-i`)
@@ -113,7 +116,7 @@ The plugin uses this hierarchy for finding FFmpeg:
 ### Adding Features
 - Camera features require updates to: settings.ts (types), config.schema.json (UI), platform.ts or streamingDelegate.ts (logic)
 - HSV features primarily live in recordingDelegate.ts and prebuffer.ts
-- Motion/doorbell automation touches platform.ts event handlers and ffmpeg.ts for detection
+- Motion/doorbell automation and FFmpeg-based motion detection live in platform.ts event handlers
 
 ### Snapshot Fetching
 The plugin intelligently chooses between two methods for fetching snapshots:
@@ -161,8 +164,33 @@ The plugin supports automatic motion detection by analyzing the video stream:
 
 **Requirements**
 - `motion: true` must be enabled (creates the motion sensor)
-- `videoConfig.subSource` must be configured
+- `videoConfig.subSource` must be configured with FFmpeg arguments
 - Camera must provide a sub stream URL
+
+**Complete Configuration Example**
+```json
+{
+  "name": "Front Camera",
+  "motion": true,
+  "ffmpegMotionDetection": true,
+  "ffmpegMotionSensitivity": 0.04,
+  "motionTimeout": 15,
+  "videoConfig": {
+    "source": "-rtsp_transport tcp -i rtsp://camera.local:554/stream0",
+    "subSource": "-rtsp_transport tcp -i rtsp://camera.local:554/stream1",
+    "stillImageSource": "http://camera.local/snapshot.jpg",
+    "recording": true,
+    "prebuffer": true
+  }
+}
+```
+
+**Important Notes**
+- `subSource` uses the same syntax as `source` (full FFmpeg arguments)
+- Stream 0 is typically the main/high-resolution stream
+- Stream 1 is typically the sub/low-resolution stream
+- The sub stream should be lower resolution to reduce CPU usage during motion analysis
+- Motion detection runs continuously and independently from HomeKit streaming
 
 ### FFmpeg Integration
 - All FFmpeg commands are split by whitespace and passed as argv arrays

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,17 @@ Cameras are configured in the platform config with these key sections:
 - `videoConfig.source` - FFmpeg input arguments (required, must include `-i`)
 - `videoConfig.subSource` - Lower resolution stream for motion detection
 - `videoConfig.stillImageSource` - Direct URL or FFmpeg source for snapshots
+  - HTTP/HTTPS URLs: `"http://camera.local/snapshot.jpg"` (no `-i` needed)
+  - FFmpeg sources: `"-i rtsp://camera.local:554/stream"` (requires `-i`)
 - `videoConfig.recording` - Enables HomeKit Secure Video
 - `videoConfig.prebuffer` - Enables video prebuffering for HSV (requires recording)
+
+### Configuration Validation
+The plugin validates camera configurations at startup (platform.ts constructor):
+- Checks for required fields (name, source)
+- Validates FFmpeg arguments include `-i` flag
+- **Intelligently skips `-i` validation** for direct HTTP/HTTPS URLs in `stillImageSource`
+- Uses the same URL detection regex as snapshot fetching (`/^https?:\/\/[^\s]+$/`)
 
 ### FFmpeg Path Resolution
 The plugin uses this hierarchy for finding FFmpeg:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ Other users have been sharing configurations that work for them on our GitHub si
 - `platform`: _(Required)_ Must always be set to `Camera-ffmpeg`.
 - `name`: _(Required)_ Set the camera name for display in the Home app.
 - `source`: _(Required)_ FFmpeg options on where to find and how to decode your camera's video stream. The most basic form is `-i` followed by your camera's URL.
-- `stillImageSource`: If your camera also provides a URL for a still image, that can be defined here with the same syntax as `source`. If not set, the plugin will grab one frame from `source`.
+- `subSource`: FFmpeg options for a lower resolution stream. Uses the same syntax as `source` (e.g., `-rtsp_transport tcp -i rtsp://camera.local:554/stream1`). **Required if you want to use `ffmpegMotionDetection`** - without this, automatic motion detection will not work. Should point to your camera's sub/low-resolution stream to reduce CPU usage.
+- `stillImageSource`: If your camera provides a snapshot URL, you can define it here. Supports two formats:
+  - **Direct URL** (recommended, faster): `http://camera.local/snapshot.jpg` - fetches images directly via HTTP/HTTPS
+  - **FFmpeg source**: `-i rtsp://camera.local:554/stream` - uses FFmpeg to extract a frame (required for RTSP or when filters are needed)
+  - If not set, the plugin will grab one frame from `source`.
 
 #### Config Example
 
@@ -35,8 +39,9 @@ Other users have been sharing configurations that work for them on our GitHub si
     {
       "name": "Camera Name",
       "videoConfig": {
-        "source": "-i rtsp://username:password@example.com:554",
-        "stillImageSource": "-i http://example.com/still_image.jpg",
+        "source": "-i rtsp://username:password@example.com:554/stream0",
+        "subSource": "-i rtsp://username:password@example.com:554/stream1",
+        "stillImageSource": "http://example.com/snapshot.jpg",
         "maxStreams": 2,
         "maxWidth": 1280,
         "maxHeight": 720,
@@ -89,7 +94,6 @@ Other users have been sharing configurations that work for them on our GitHub si
 
 ### Optional videoConfig Parameters
 
-- `subSource`: FFmpeg options for a lower resolution stream used for motion detection. Uses the same syntax as `source`. This should point to your camera's sub stream (typically stream1). Required if `ffmpegMotionDetection` is enabled. Example: `-rtsp_transport tcp -i rtsp://camera.local:554/stream1`
 - `returnAudioTarget`: _(EXPERIMENTAL - WIP)_ The FFmpeg output command for directing audio back to a two-way capable camera. This feature is still in development and a configuration that works today may not work in the future.
 - `maxStreams`: The maximum number of streams that will be allowed at once to this camera. (Default: `2`)
 - `maxWidth`: The maximum width used for video streamed to HomeKit. If set to 0, the resolution of the source is used. If not set, will use any size HomeKit requests.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Other users have been sharing configurations that work for them on our GitHub si
 - `switches`: Enables dummy switches to trigger motion and/or doorbell, if either of those are enabled. When enabled there will be an additional switch that triggers the motion or doorbell event. See the project site for [more detailed instructions](https://homebridge-plugins.github.io/homebridge-camera-ffmpeg/automation/switch.html). (Default: `false`)
 - `motionTimeout`: The number of seconds after triggering to reset the motion sensor. Set to 0 to disable resetting of motion trigger for MQTT or HTTP. (Default: `1`)
 - `motionDoorbell`: Rings the doorbell when motion is activated. This allows for motion alerts to appear on Apple TVs. (Default: `false`)
+- `ffmpegMotionDetection`: Enables automatic motion detection by analyzing the video stream using FFmpeg scene change detection. Requires `motion` to be enabled and `subSource` to be configured in `videoConfig`. (Default: `false`)
+- `ffmpegMotionSensitivity`: Sensitivity threshold for FFmpeg motion detection. Lower values are more sensitive (range: 0.01-0.1). (Default: `0.03`)
 - `manufacturer`: Set the manufacturer name for display in the Home app. (Default: `Homebridge`)
 - `model`: Set the model for display in the Home app. (Default: `Camera FFmpeg`)
 - `serialNumber`: Set the serial number for display in the Home app. (Default: `SerialNumber`)
@@ -87,6 +89,7 @@ Other users have been sharing configurations that work for them on our GitHub si
 
 ### Optional videoConfig Parameters
 
+- `subSource`: FFmpeg options for a lower resolution stream used for motion detection. Uses the same syntax as `source`. This should point to your camera's sub stream (typically stream1). Required if `ffmpegMotionDetection` is enabled. Example: `-rtsp_transport tcp -i rtsp://camera.local:554/stream1`
 - `returnAudioTarget`: _(EXPERIMENTAL - WIP)_ The FFmpeg output command for directing audio back to a two-way capable camera. This feature is still in development and a configuration that works today may not work in the future.
 - `maxStreams`: The maximum number of streams that will be allowed at once to this camera. (Default: `2`)
 - `maxWidth`: The maximum width used for video streamed to HomeKit. If set to 0, the resolution of the source is used. If not set, will use any size HomeKit requests.
@@ -164,6 +167,59 @@ Other users have been sharing configurations that work for them on our GitHub si
   ]
 }
 ```
+
+### FFmpeg Motion Detection
+
+This plugin supports automatic motion detection by analyzing the video stream using FFmpeg's scene change detection filter. This eliminates the need for external motion detection systems or camera motion events.
+
+#### How It Works
+
+- Uses FFmpeg's `scene` filter to detect significant changes in the video
+- Analyzes a lower-resolution stream (`subSource`) to reduce CPU usage
+- Automatically triggers the HomeKit motion sensor when motion is detected
+- Includes configurable sensitivity and cooldown periods
+
+#### Requirements
+
+- `motion` must be enabled (creates the motion sensor)
+- `videoConfig.subSource` must be configured with your camera's sub stream
+- Your camera must provide a lower-resolution stream (typically called "sub stream" or "stream1")
+
+#### Configuration Options
+
+- `ffmpegMotionDetection`: Enable automatic motion detection (Default: `false`)
+- `ffmpegMotionSensitivity`: Detection threshold, lower = more sensitive (0.01-0.1, Default: `0.03`)
+- `motionTimeout`: Seconds before resetting the motion sensor (Default: `1`)
+- `videoConfig.subSource`: FFmpeg arguments for the sub stream (same syntax as `source`)
+
+#### FFmpeg Motion Detection Example
+
+```json
+{
+  "platform": "Camera-ffmpeg",
+  "cameras": [
+    {
+      "name": "Front Camera",
+      "motion": true,
+      "ffmpegMotionDetection": true,
+      "ffmpegMotionSensitivity": 0.04,
+      "motionTimeout": 15,
+      "videoConfig": {
+        "source": "-rtsp_transport tcp -i rtsp://camera.local:554/stream0",
+        "subSource": "-rtsp_transport tcp -i rtsp://camera.local:554/stream1",
+        "stillImageSource": "http://camera.local/snapshot.jpg"
+      }
+    }
+  ]
+}
+```
+
+**Important Notes:**
+- Stream 0 is typically the main/high-resolution stream
+- Stream 1 is typically the sub/low-resolution stream
+- Using the sub stream reduces CPU usage during motion analysis
+- Motion detection runs continuously and independently from HomeKit streaming
+- The process auto-restarts on failure with a 10-second delay
 
 ### Automation Parameters
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -119,6 +119,19 @@
             "type": "boolean",
             "description": "Rings the doorbell when motion is activated. This allows for motion alerts to appear on Apple TVs."
           },
+          "ffmpegMotionDetection": {
+            "title": "FFmpeg Motion Detection",
+            "type": "boolean",
+            "description": "Enables automatic motion detection by analyzing the video stream using FFmpeg scene change detection. Requires subSource to be configured in Video Configuration."
+          },
+          "ffmpegMotionSensitivity": {
+            "title": "FFmpeg Motion Sensitivity",
+            "type": "number",
+            "placeholder": 0.03,
+            "minimum": 0.01,
+            "maximum": 0.1,
+            "description": "Sensitivity threshold for FFmpeg motion detection. Lower values are more sensitive (0.01-0.1). Default is 0.03."
+          },
           "videoConfig": {
             "title": "Video Configuration",
             "type": "object",
@@ -129,6 +142,12 @@
                 "placeholder": "-i rtsp://username:password@example.com:554",
                 "required": true,
                 "description": "FFmpeg options on where to find and how to decode your camera's video stream. The most basic form is '-i' followed by your camera's URL."
+              },
+              "subSource": {
+                "title": "Sub Stream Source (for Motion Detection)",
+                "type": "string",
+                "placeholder": "rtsp://username:password@example.com:554/sub",
+                "description": "A lower resolution stream URL for FFmpeg motion detection. Using a sub stream reduces CPU usage. Required if FFmpeg Motion Detection is enabled."
               },
               "stillImageSource": {
                 "title": "Still Image Source",
@@ -323,6 +342,7 @@
           "items": [
             "cameras[].name",
             "cameras[].videoConfig.source",
+            "cameras[].videoConfig.subSource",
             "cameras[].videoConfig.stillImageSource",
             "cameras[].videoConfig.audio",
             {
@@ -394,6 +414,8 @@
                 "cameras[].switches",
                 "cameras[].motionTimeout",
                 "cameras[].motionDoorbell",
+                "cameras[].ffmpegMotionDetection",
+                "cameras[].ffmpegMotionSensitivity",
                 {
                   "key": "cameras[]",
                   "type": "section",

--- a/config.schema.json
+++ b/config.schema.json
@@ -146,8 +146,8 @@
               "subSource": {
                 "title": "Sub Stream Source (for Motion Detection)",
                 "type": "string",
-                "placeholder": "rtsp://username:password@example.com:554/sub",
-                "description": "A lower resolution stream URL for FFmpeg motion detection. Using a sub stream reduces CPU usage. Required if FFmpeg Motion Detection is enabled."
+                "placeholder": "-rtsp_transport tcp -i rtsp://username:password@example.com:554/sub",
+                "description": "FFmpeg options for a lower resolution stream used for motion detection. Same syntax as 'source'. Using a sub stream reduces CPU usage. Required if FFmpeg Motion Detection is enabled."
               },
               "stillImageSource": {
                 "title": "Still Image Source",

--- a/src/ffmpeg.ts
+++ b/src/ffmpeg.ts
@@ -5,7 +5,6 @@ import type { StreamRequestCallback } from 'homebridge'
 
 import type { Logger } from './logger.js'
 import type { StreamingDelegate } from './streamingDelegate.js'
-import type { CameraConfig } from './settings.js'
 
 import { spawn } from 'node:child_process'
 import os from 'node:os'
@@ -17,9 +16,6 @@ export class FfmpegProcess {
   private readonly process: ChildProcessWithoutNullStreams
   private killTimeout?: NodeJS.Timeout
   readonly stdin: Writable
-  private motionProcess?: ChildProcessWithoutNullStreams
-  private lastMotionTime?: number
-  private motionRestartTimeout?: NodeJS.Timeout
 
   constructor(cameraName: string, sessionId: string, videoProcessor: string, ffmpegArgs: string, log: Logger, debug = false, delegate: StreamingDelegate, callback?: StreamRequestCallback) {
     log.debug(`Stream command: ${videoProcessor} ${ffmpegArgs}`, cameraName, debug)
@@ -132,93 +128,5 @@ export class FfmpegProcess {
     this.killTimeout = setTimeout(() => {
       this.process.kill('SIGKILL')
     }, 2 * 1000)
-  }
-
-  public startMotionDetection(
-    cameraName: string,
-    cameraConfig: CameraConfig,
-    videoProcessor: string,
-    log: Logger,
-    motionDetectedCallback: () => void
-  ): void {
-    if (!cameraConfig.videoConfig?.subSource) {
-      log.error('FFmpeg motion detection requires subSource to be configured', cameraName)
-      return
-    }
-
-    const subSource = cameraConfig.videoConfig.subSource
-    const cooldownSeconds = cameraConfig.motionTimeout ?? 15
-    const sensitivityThreshold = cameraConfig.ffmpegMotionSensitivity ?? 0.03
-
-    log.info(
-      `Starting FFmpeg motion detection (sensitivity: ${sensitivityThreshold}, cooldown: ${cooldownSeconds}s)`,
-      cameraName
-    )
-
-    const motionArgs = [
-      '-hide_banner',
-      '-loglevel',
-      'info',
-      '-rtsp_transport',
-      'tcp',
-      '-i',
-      subSource,
-      '-vf',
-      `select='gt(scene,${sensitivityThreshold})',metadata=print`,
-      '-an',
-      '-f',
-      'null',
-      '-',
-    ]
-
-    this.motionProcess = spawn(videoProcessor, motionArgs, { env })
-
-    const stderr = readline.createInterface({
-      input: this.motionProcess.stderr,
-      terminal: false,
-    })
-
-    stderr.on('line', (line: string) => {
-      const match = line.match(/scene_score=([0-9.]+)/)
-      if (match) {
-        const score = Number.parseFloat(match[1])
-        if (score > sensitivityThreshold) {
-          const now = Date.now()
-          if (!this.lastMotionTime || now - this.lastMotionTime > cooldownSeconds * 1000) {
-            this.lastMotionTime = now
-            log.info(`Motion detected (score: ${score.toFixed(4)})`, cameraName)
-            motionDetectedCallback()
-          }
-        }
-      }
-    })
-
-    this.motionProcess.on('error', (error: Error) => {
-      log.error(`FFmpeg motion detection process error: ${error.message}`, cameraName)
-    })
-
-    this.motionProcess.on('close', (code: number) => {
-      log.warn(`FFmpeg motion detection exited with code ${code}, restarting in 10 seconds...`, cameraName)
-
-      if (this.motionRestartTimeout) {
-        clearTimeout(this.motionRestartTimeout)
-      }
-
-      this.motionRestartTimeout = setTimeout(() => {
-        this.startMotionDetection(cameraName, cameraConfig, videoProcessor, log, motionDetectedCallback)
-      }, 10000)
-    })
-  }
-
-  public stopMotionDetection(): void {
-    if (this.motionRestartTimeout) {
-      clearTimeout(this.motionRestartTimeout)
-      this.motionRestartTimeout = undefined
-    }
-
-    if (this.motionProcess) {
-      this.motionProcess.kill('SIGTERM')
-      this.motionProcess = undefined
-    }
   }
 }

--- a/src/ffmpeg.ts
+++ b/src/ffmpeg.ts
@@ -5,6 +5,7 @@ import type { StreamRequestCallback } from 'homebridge'
 
 import type { Logger } from './logger.js'
 import type { StreamingDelegate } from './streamingDelegate.js'
+import type { CameraConfig } from './settings.js'
 
 import { spawn } from 'node:child_process'
 import os from 'node:os'
@@ -16,6 +17,9 @@ export class FfmpegProcess {
   private readonly process: ChildProcessWithoutNullStreams
   private killTimeout?: NodeJS.Timeout
   readonly stdin: Writable
+  private motionProcess?: ChildProcessWithoutNullStreams
+  private lastMotionTime?: number
+  private motionRestartTimeout?: NodeJS.Timeout
 
   constructor(cameraName: string, sessionId: string, videoProcessor: string, ffmpegArgs: string, log: Logger, debug = false, delegate: StreamingDelegate, callback?: StreamRequestCallback) {
     log.debug(`Stream command: ${videoProcessor} ${ffmpegArgs}`, cameraName, debug)
@@ -128,5 +132,93 @@ export class FfmpegProcess {
     this.killTimeout = setTimeout(() => {
       this.process.kill('SIGKILL')
     }, 2 * 1000)
+  }
+
+  public startMotionDetection(
+    cameraName: string,
+    cameraConfig: CameraConfig,
+    videoProcessor: string,
+    log: Logger,
+    motionDetectedCallback: () => void
+  ): void {
+    if (!cameraConfig.videoConfig?.subSource) {
+      log.error('FFmpeg motion detection requires subSource to be configured', cameraName)
+      return
+    }
+
+    const subSource = cameraConfig.videoConfig.subSource
+    const cooldownSeconds = cameraConfig.motionTimeout ?? 15
+    const sensitivityThreshold = cameraConfig.ffmpegMotionSensitivity ?? 0.03
+
+    log.info(
+      `Starting FFmpeg motion detection (sensitivity: ${sensitivityThreshold}, cooldown: ${cooldownSeconds}s)`,
+      cameraName
+    )
+
+    const motionArgs = [
+      '-hide_banner',
+      '-loglevel',
+      'info',
+      '-rtsp_transport',
+      'tcp',
+      '-i',
+      subSource,
+      '-vf',
+      `select='gt(scene,${sensitivityThreshold})',metadata=print`,
+      '-an',
+      '-f',
+      'null',
+      '-',
+    ]
+
+    this.motionProcess = spawn(videoProcessor, motionArgs, { env })
+
+    const stderr = readline.createInterface({
+      input: this.motionProcess.stderr,
+      terminal: false,
+    })
+
+    stderr.on('line', (line: string) => {
+      const match = line.match(/scene_score=([0-9.]+)/)
+      if (match) {
+        const score = Number.parseFloat(match[1])
+        if (score > sensitivityThreshold) {
+          const now = Date.now()
+          if (!this.lastMotionTime || now - this.lastMotionTime > cooldownSeconds * 1000) {
+            this.lastMotionTime = now
+            log.info(`Motion detected (score: ${score.toFixed(4)})`, cameraName)
+            motionDetectedCallback()
+          }
+        }
+      }
+    })
+
+    this.motionProcess.on('error', (error: Error) => {
+      log.error(`FFmpeg motion detection process error: ${error.message}`, cameraName)
+    })
+
+    this.motionProcess.on('close', (code: number) => {
+      log.warn(`FFmpeg motion detection exited with code ${code}, restarting in 10 seconds...`, cameraName)
+
+      if (this.motionRestartTimeout) {
+        clearTimeout(this.motionRestartTimeout)
+      }
+
+      this.motionRestartTimeout = setTimeout(() => {
+        this.startMotionDetection(cameraName, cameraConfig, videoProcessor, log, motionDetectedCallback)
+      }, 10000)
+    })
+  }
+
+  public stopMotionDetection(): void {
+    if (this.motionRestartTimeout) {
+      clearTimeout(this.motionRestartTimeout)
+      this.motionRestartTimeout = undefined
+    }
+
+    if (this.motionProcess) {
+      this.motionProcess.kill('SIGTERM')
+      this.motionProcess = undefined
+    }
   }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -54,9 +54,16 @@ export class FfmpegPlatform implements DynamicPlatformPlugin {
           }
         }
         if (cameraConfig.videoConfig.stillImageSource) {
-          const stillArgs = cameraConfig.videoConfig.stillImageSource.split(/\s+/)
-          if (!stillArgs.includes('-i')) {
-            this.log.warn('The stillImageSource for this camera is missing "-i", it is likely misconfigured.', cameraConfig.name)
+          const stillSource = cameraConfig.videoConfig.stillImageSource.trim()
+          // Check if it's a direct HTTP/HTTPS URL (doesn't need -i)
+          const isDirectUrl = /^https?:\/\/[^\s]+$/.test(stillSource)
+
+          if (!isDirectUrl) {
+            // Only validate FFmpeg-style sources
+            const stillArgs = stillSource.split(/\s+/)
+            if (!stillArgs.includes('-i')) {
+              this.log.warn('The stillImageSource for this camera is missing "-i", it is likely misconfigured.', cameraConfig.name)
+            }
           }
         }
         if (cameraConfig.videoConfig.vcodec === 'copy' && cameraConfig.videoConfig.videoFilter) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,4 +1,5 @@
 import type { Buffer } from 'node:buffer'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 
 import type { API, CharacteristicSetCallback, CharacteristicValue, DynamicPlatformPlugin, Logging, PlatformAccessory, PlatformConfig } from 'homebridge'
 
@@ -6,6 +7,9 @@ import type { AutomationReturn } from "./settings.js"
 import type { CameraConfig, FfmpegPlatformConfig } from './settings.js'
 
 import http from 'node:http'
+import { spawn } from 'node:child_process'
+import { env } from 'node:process'
+import readline from 'node:readline'
 
 import { APIEvent, CharacteristicEventTypes, PlatformAccessoryEvent } from 'homebridge'
 import mqtt from 'mqtt'
@@ -15,6 +19,12 @@ import { StreamingDelegate } from './streamingDelegate.js'
 import { PLUGIN_NAME, PLATFORM_NAME, MqttAction, getVersion } from './settings.js'
 
 const version = getVersion()
+
+interface MotionDetectionInfo {
+  process: ChildProcessWithoutNullStreams
+  restartTimeout?: NodeJS.Timeout
+  lastMotionTime?: number
+}
 
 export class FfmpegPlatform implements DynamicPlatformPlugin {
   private readonly log: Logger
@@ -26,6 +36,7 @@ export class FfmpegPlatform implements DynamicPlatformPlugin {
   private readonly motionTimers: Map<string, NodeJS.Timeout> = new Map()
   private readonly doorbellTimers: Map<string, NodeJS.Timeout> = new Map()
   private readonly mqttActions: Map<string, Map<string, Array<MqttAction>>> = new Map()
+  private readonly motionDetectionProcesses: Map<string, MotionDetectionInfo> = new Map()
 
   constructor(log: Logging, config: PlatformConfig, api: API) {
     this.log = new Logger(log)
@@ -158,6 +169,11 @@ export class FfmpegPlatform implements DynamicPlatformPlugin {
             callback()
           })
         accessory.addService(motionTrigger)
+      }
+
+      // Setup FFmpeg-based motion detection if enabled
+      if (cameraConfig.ffmpegMotionDetection && cameraConfig.videoConfig?.subSource) {
+        this.startMotionDetection(accessory, cameraConfig)
       }
     }
 
@@ -341,6 +357,97 @@ export class FfmpegPlatform implements DynamicPlatformPlugin {
         error: true,
         message: `Camera "${name}" not found.`,
       }
+    }
+  }
+
+  private startMotionDetection(accessory: PlatformAccessory, cameraConfig: CameraConfig): void {
+    if (!cameraConfig.videoConfig?.subSource) {
+      this.log.error('FFmpeg motion detection requires subSource to be configured', cameraConfig.name)
+      return
+    }
+
+    const subSource = cameraConfig.videoConfig.subSource
+    const cooldownSeconds = cameraConfig.motionTimeout ?? 15
+    const sensitivityThreshold = cameraConfig.ffmpegMotionSensitivity ?? 0.03
+    const videoProcessor = this.config.videoProcessor || 'ffmpeg'
+
+    this.log.info(
+      `Starting FFmpeg motion detection (sensitivity: ${sensitivityThreshold}, cooldown: ${cooldownSeconds}s)`,
+      cameraConfig.name
+    )
+
+    const motionArgs = [
+      '-hide_banner',
+      '-loglevel',
+      'info',
+      '-rtsp_transport',
+      'tcp',
+      '-i',
+      subSource,
+      '-vf',
+      `select='gt(scene,${sensitivityThreshold})',metadata=print`,
+      '-an',
+      '-f',
+      'null',
+      '-',
+    ]
+
+    const motionProcess = spawn(videoProcessor, motionArgs, { env })
+
+    const stderr = readline.createInterface({
+      input: motionProcess.stderr,
+      terminal: false,
+    })
+
+    stderr.on('line', (line: string) => {
+      const match = line.match(/scene_score=([0-9.]+)/)
+      if (match) {
+        const score = Number.parseFloat(match[1])
+        if (score > sensitivityThreshold) {
+          const now = Date.now()
+          const info = this.motionDetectionProcesses.get(accessory.UUID)
+          if (info && (!info.lastMotionTime || now - info.lastMotionTime > cooldownSeconds * 1000)) {
+            info.lastMotionTime = now
+            this.log.info(`Motion detected (score: ${score.toFixed(4)})`, cameraConfig.name)
+            this.motionHandler(accessory, true)
+          }
+        }
+      }
+    })
+
+    motionProcess.on('error', (error: Error) => {
+      this.log.error(`FFmpeg motion detection process error: ${error.message}`, cameraConfig.name)
+    })
+
+    motionProcess.on('close', (code: number) => {
+      this.log.warn(`FFmpeg motion detection exited with code ${code}, restarting in 10 seconds...`, cameraConfig.name)
+
+      const info = this.motionDetectionProcesses.get(accessory.UUID)
+      if (info) {
+        if (info.restartTimeout) {
+          clearTimeout(info.restartTimeout)
+        }
+
+        info.restartTimeout = setTimeout(() => {
+          this.motionDetectionProcesses.delete(accessory.UUID)
+          this.startMotionDetection(accessory, cameraConfig)
+        }, 10000)
+      }
+    })
+
+    this.motionDetectionProcesses.set(accessory.UUID, {
+      process: motionProcess,
+    })
+  }
+
+  private stopMotionDetection(accessory: PlatformAccessory): void {
+    const info = this.motionDetectionProcesses.get(accessory.UUID)
+    if (info) {
+      if (info.restartTimeout) {
+        clearTimeout(info.restartTimeout)
+      }
+      info.process.kill('SIGTERM')
+      this.motionDetectionProcesses.delete(accessory.UUID)
     }
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -366,7 +366,7 @@ export class FfmpegPlatform implements DynamicPlatformPlugin {
       return
     }
 
-    const subSource = cameraConfig.videoConfig.subSource
+    const subSourceArgs = cameraConfig.videoConfig.subSource.split(/\s+/)
     const cooldownSeconds = cameraConfig.motionTimeout ?? 15
     const sensitivityThreshold = cameraConfig.ffmpegMotionSensitivity ?? 0.03
     const videoProcessor = this.config.videoProcessor || 'ffmpeg'
@@ -380,10 +380,7 @@ export class FfmpegPlatform implements DynamicPlatformPlugin {
       '-hide_banner',
       '-loglevel',
       'info',
-      '-rtsp_transport',
-      'tcp',
-      '-i',
-      subSource,
+      ...subSourceArgs,
       '-vf',
       `select='gt(scene,${sensitivityThreshold})',metadata=print`,
       '-an',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -51,12 +51,15 @@ export interface CameraConfig {
   switches?: boolean
   motionTimeout?: number
   motionDoorbell?: boolean
+  ffmpegMotionDetection?: boolean
+  ffmpegMotionSensitivity?: number
   mqtt?: MqttCameraConfig
   videoConfig?: VideoConfig
 }
 
 export interface VideoConfig {
   source?: string
+  subSource?: string
   stillImageSource?: string
   returnAudioTarget?: string
   maxStreams?: number

--- a/src/streamingDelegate.ts
+++ b/src/streamingDelegate.ts
@@ -6,6 +6,8 @@ import type { Logger } from './logger.js'
 import { Buffer } from 'node:buffer'
 import { spawn } from 'node:child_process'
 import { createSocket, Socket } from 'node:dgram'
+import http from 'node:http'
+import https from 'node:https'
 import { env } from 'node:process'
 
 import { defaultFfmpegPath } from '@homebridge/camera-utils'
@@ -193,53 +195,113 @@ export class StreamingDelegate implements CameraStreamingDelegate {
   fetchSnapshot(snapFilter?: string): Promise<Buffer> {
     this.snapshotPromise = new Promise((resolve, reject) => {
       const startTime = Date.now()
-      const ffmpegArgs = `${this.videoConfig.stillImageSource || this.videoConfig.source! // Still
-      } -frames:v 1${snapFilter ? ` -filter:v ${snapFilter}` : ''
-      } -f image2 -`
-      + ` -hide_banner`
-      + ` -loglevel error`
+      const source = this.videoConfig.stillImageSource || this.videoConfig.source!
 
-      this.log.debug(`Snapshot command: ${this.videoProcessor} ${ffmpegArgs}`, this.cameraName, this.videoConfig.debug)
-      const ffmpeg = spawn(this.videoProcessor, ffmpegArgs.split(/\s+/), { env })
+      // Check if source is a direct HTTP/HTTPS URL (not FFmpeg args)
+      // A direct URL doesn't contain spaces and starts with http:// or https://
+      const isDirectUrl = /^https?:\/\/[^\s]+$/.test(source.trim())
 
-      let snapshotBuffer = Buffer.alloc(0)
-      ffmpeg.stdout.on('data', (data) => {
-        snapshotBuffer = Buffer.concat([snapshotBuffer, data])
-      })
-      ffmpeg.on('error', (error: Error) => {
-        reject(new Error(`FFmpeg process creation failed: ${error.message}`))
-      })
-      ffmpeg.stderr.on('data', (data) => {
-        data.toString().split('\n').forEach((line: string) => {
-          if (this.videoConfig.debug && line.length > 0) { // For now only write anything out when debug is set
-            this.log.error(line, `${this.cameraName}] [Snapshot`)
+      if (isDirectUrl) {
+        // Direct HTTP/HTTPS fetch - much faster and more efficient
+        this.log.debug(`Fetching snapshot via HTTP: ${source}`, this.cameraName, this.videoConfig.debug)
+        const client = source.startsWith('https') ? https : http
+
+        const req = client.get(source, { timeout: 10000 }, (res) => {
+          if (res.statusCode !== 200) {
+            reject(new Error(`Failed to fetch snapshot, HTTP status: ${res.statusCode}`))
+            res.resume()
+            return
+          }
+
+          const chunks: Buffer[] = []
+          res.on('data', (chunk) => {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+          })
+
+          res.on('end', () => {
+            const snapshotBuffer = Buffer.concat(chunks)
+            if (snapshotBuffer.length > 0) {
+              resolve(snapshotBuffer)
+            } else {
+              reject(new Error('Failed to fetch snapshot: empty response'))
+            }
+
+            setTimeout(() => {
+              this.snapshotPromise = undefined
+            }, 3 * 1000) // Expire cached snapshot after 3 seconds
+
+            const runtime = (Date.now() - startTime) / 1000
+            let message = `Fetching snapshot took ${runtime} seconds.`
+            if (runtime < 5) {
+              this.log.debug(message, this.cameraName, this.videoConfig.debug)
+            } else {
+              if (runtime < 22) {
+                this.log.warn(message, this.cameraName)
+              } else {
+                message += ' The request has timed out and the snapshot has not been refreshed in HomeKit.'
+                this.log.error(message, this.cameraName)
+              }
+            }
+          })
+        })
+
+        req.on('error', (err) => {
+          reject(new Error(`HTTP snapshot error: ${err.message}`))
+        })
+
+        req.on('timeout', () => {
+          req.destroy()
+          reject(new Error('HTTP snapshot request timed out'))
+        })
+      } else {
+        // Use FFmpeg for RTSP streams, FFmpeg args, or when filters are needed
+        const ffmpegArgs = `${source} -frames:v 1${snapFilter ? ` -filter:v ${snapFilter}` : ''
+        } -f image2 -`
+        + ` -hide_banner`
+        + ` -loglevel error`
+
+        this.log.debug(`Snapshot command: ${this.videoProcessor} ${ffmpegArgs}`, this.cameraName, this.videoConfig.debug)
+        const ffmpeg = spawn(this.videoProcessor, ffmpegArgs.split(/\s+/), { env })
+
+        let snapshotBuffer = Buffer.alloc(0)
+        ffmpeg.stdout.on('data', (data) => {
+          snapshotBuffer = Buffer.concat([snapshotBuffer, data])
+        })
+        ffmpeg.on('error', (error: Error) => {
+          reject(new Error(`FFmpeg process creation failed: ${error.message}`))
+        })
+        ffmpeg.stderr.on('data', (data) => {
+          data.toString().split('\n').forEach((line: string) => {
+            if (this.videoConfig.debug && line.length > 0) {
+              this.log.error(line, `${this.cameraName}] [Snapshot`)
+            }
+          })
+        })
+        ffmpeg.on('close', () => {
+          if (snapshotBuffer.length > 0) {
+            resolve(snapshotBuffer)
+          } else {
+            reject(new Error('Failed to fetch snapshot.'))
+          }
+
+          setTimeout(() => {
+            this.snapshotPromise = undefined
+          }, 3 * 1000) // Expire cached snapshot after 3 seconds
+
+          const runtime = (Date.now() - startTime) / 1000
+          let message = `Fetching snapshot took ${runtime} seconds.`
+          if (runtime < 5) {
+            this.log.debug(message, this.cameraName, this.videoConfig.debug)
+          } else {
+            if (runtime < 22) {
+              this.log.warn(message, this.cameraName)
+            } else {
+              message += ' The request has timed out and the snapshot has not been refreshed in HomeKit.'
+              this.log.error(message, this.cameraName)
+            }
           }
         })
-      })
-      ffmpeg.on('close', () => {
-        if (snapshotBuffer.length > 0) {
-          resolve(snapshotBuffer)
-        } else {
-          reject(new Error('Failed to fetch snapshot.'))
-        }
-
-        setTimeout(() => {
-          this.snapshotPromise = undefined
-        }, 3 * 1000) // Expire cached snapshot after 3 seconds
-
-        const runtime = (Date.now() - startTime) / 1000
-        let message = `Fetching snapshot took ${runtime} seconds.`
-        if (runtime < 5) {
-          this.log.debug(message, this.cameraName, this.videoConfig.debug)
-        } else {
-          if (runtime < 22) {
-            this.log.warn(message, this.cameraName)
-          } else {
-            message += ' The request has timed out and the snapshot has not been refreshed in HomeKit.'
-            this.log.error(message, this.cameraName)
-          }
-        }
-      })
+      }
     })
     return this.snapshotPromise
   }


### PR DESCRIPTION
## :recycle: Current situation

Currently, the plugin requires external motion detection systems (MQTT, HTTP triggers, or
camera motion events) to trigger the HomeKit motion sensor. Many IP cameras support motion
detection but don't expose it via MQTT or HTTP, requiring users to set up additional
automation systems.

Additionally, the snapshot fetching always used FFmpeg even for simple HTTP URLs, adding
unnecessary overhead.

## :bulb: Proposed solution

This PR adds **FFmpeg-based motion detection** using scene change analysis, allowing the
plugin to automatically detect motion by analyzing the camera's video stream without external
 dependencies.

**Key changes:**
- Added `ffmpegMotionDetection` option to enable automatic motion detection
- Added `ffmpegMotionSensitivity` to control detection threshold (0.01-0.1)
- Added `videoConfig.subSource` to specify a lower-resolution stream for motion analysis
(reduces CPU usage)
- Optimized snapshot fetching to use direct HTTP/HTTPS requests when `stillImageSource` is a
plain URL (faster than FFmpeg)
- Updated configuration validation to intelligently handle both URL formats

The motion detection process runs independently from streaming, auto-restarts on failure, and
 integrates seamlessly with existing motion handlers.

## :gear: Release Notes

**New Features:**
- **Automatic Motion Detection**: Enable `ffmpegMotionDetection` to automatically detect
motion using FFmpeg scene analysis
- **Sub Stream Support**: Configure `videoConfig.subSource` to use a lower-resolution stream
for motion detection (reduces CPU usage)
- **Faster Snapshots**: Direct HTTP/HTTPS snapshot URLs now bypass FFmpeg for improved
performance

**Configuration:**
```json
{
  "name": "Front Camera",
  "motion": true,
  "ffmpegMotionDetection": true,
  "ffmpegMotionSensitivity": 0.04,
  "videoConfig": {
    "source": "-i rtsp://camera.local:554/stream0",
    "subSource": "-i rtsp://camera.local:554/stream1",
    "stillImageSource": "http://camera.local/snapshot.jpg"
  }
}
```

Breaking Changes: None - all new features are opt-in.

:heavy_plus_sign: Additional Information

Testing

- Motion detection tested with RTSP streams using scene filter
- Snapshot fetching tested with both HTTP URLs and FFmpeg sources
- Configuration validation tested for various stillImageSource and subSource formats
- Auto-restart behavior verified on FFmpeg process failures

Edge cases not yet covered: Very high-FPS streams, cameras with unusual scene change
patterns.

Reviewer Nudging

Start with platform.ts:startMotionDetection() (line ~720) to see the motion detection
implementation, then check streamingDelegate.ts:fetchSnapshot() for the snapshot
optimization. Configuration validation is in platform.ts constructor.
